### PR TITLE
Capybara's RSpec matchers available when both are available

### DIFF
--- a/lib/spinach/capybara.rb
+++ b/lib/spinach/capybara.rb
@@ -24,6 +24,7 @@ module Spinach
       def self.included(base)
         base.class_eval do
           include ::Capybara::DSL
+          include ::Capybara::RSpecMatchers if defined?(RSpec)
         end
         Spinach.hooks.before_scenario do
           ::Capybara.current_session.reset! if ::Capybara.app


### PR DESCRIPTION
If you're using spinach with RSpec and Capybara you can't do:

```
page.should have_content(@user.email)
```

Because the Capybara::RSpecMatchers was not included into the featuresteps. Didn't really know how the hell to test this, that's why no tests are included, if you have any suggestion... but it seems to work :)
