### PR TITLE
Executing hooks filtered by tags

### DIFF
--- a/test/spinach/hooks_test.rb
+++ b/test/spinach/hooks_test.rb
@@ -25,4 +25,32 @@ describe Spinach::Hooks do
       end
     end
   end
+
+  describe "hooks with tag filters" do
+    before do
+      feature_data = {
+        'name' => 'My ridiculously awesome feature',
+        'elements' => [
+          {"name" => "scenario", "steps" => ["",""]}
+        ],
+        "tags" => [{"name" => "@cool", "line" => 1}]
+      }
+      @feature = Spinach::Runner::FeatureRunner.new("my_feature")
+      @feature.stubs(:data).returns(feature_data)
+      @@flag = 0
+    end
+
+    it "if any tag filter is set only executes those that match it" do
+      Spinach.hooks.before_feature :tags => "@cool" do |data|
+        @@flag = 1
+      end
+      Spinach.hooks.before_feature :tags => ["@lame","@so_so"] do |data|
+        @@flag = 2
+      end
+
+      @@flag.must_equal 0
+      @feature.run
+      @@flag.must_equal 1
+    end
+  end
 end


### PR DESCRIPTION
Seems that we were doing this at the same time :) My approach is different than yours here, while yours is cleaner.

The way I see it, maybe it would be useful to have a hash of options for the hooks. Also, this way you don't care if you're dealing with a feature or a scenario or whatever, if it has data and tags it's filtered.

I don't quite like the way I assume that the data is the last argument of the callback..

Anyway, I don't mean to have this pulled but to show you what was my idea on the subject. Was thinking that filtering features by tags in CLI would be cool to but that's another story
