### PR TITLE
Require env.rb before other support files and step definitions

### DIFF
--- a/lib/spinach/runner.rb
+++ b/lib/spinach/runner.rb
@@ -70,11 +70,12 @@ module Spinach
       successful
     end
 
-    # Loads step definitions and support files.
+    # Loads support files and step definitions, ensuring that env.rb is loaded
+    # first.
     #
     # @api public
     def require_dependencies
-      (support_files + step_definition_files).each do |file|
+      required_files.each do |file|
         require file
       end
     end
@@ -104,6 +105,32 @@ module Spinach
         File.expand_path File.join(support_path, '**', '*.rb')
       )
     end
+
+    # @return [Array<String>] files
+    #   The environment support file env.rb.
+    #
+    # @api public
+    def environment_file
+      support_files.select {|f| f =~ %r{#{File::SEPARATOR}#{support_path}#{File::SEPARATOR}env.rb} }
+    end
+
+    # @return [Array<String>] files
+    #   The support files excluding env.rb
+    #
+    # @api public
+    def support_files_minus_env
+      support_files - environment_file
+    end
+
+    # @return [Array<String>] files
+    #   All support files with env.rb ordered first, followed by the step
+    #   definitions.
+    #
+    # @api public
+    def required_files
+      environment_file + support_files_minus_env + step_definition_files
+    end
+
   end
 end
 

--- a/test/spinach/runner_test.rb
+++ b/test/spinach/runner_test.rb
@@ -56,15 +56,27 @@ describe Spinach::Runner do
       runner.run
     end
   end
+
   describe '#require_dependencies' do
     it 'requires support files and step definitions' do
       runner.stubs(
-        support_files: ['a', 'b'], step_definition_files: ['c', 'd']
+        required_files: ['a', 'b']
       )
-      %w{a b c d}.each do |file|
+      %w{a b}.each do |file|
         runner.expects(:require).with(file)
       end
       runner.require_dependencies
     end
   end
+
+  describe '#required_files' do
+    it 'requires environment files first' do
+      runner.stubs(:step_definition_path).returns('steps')
+      runner.stubs(:support_path).returns('support')
+      runner.stubs(:support_files).returns(['/support/bar.rb', '/support/env.rb', '/support/quz.rb'])
+      runner.stubs(:step_definition_files).returns(['/steps/bar.feature'])
+      runner.required_files.must_equal(['/support/env.rb', '/support/bar.rb', '/support/quz.rb', '/steps/bar.feature'])
+    end
+  end
+
 end


### PR DESCRIPTION
This follows the convention used by Cucumber where support/env.\* files get required first. In this implementation I only look for an env.rb explicitly, but it suited my purposes.
