### PR TITLE
Underscore generated step methods

### DIFF
--- a/lib/spinach/support.rb
+++ b/lib/spinach/support.rb
@@ -35,6 +35,7 @@ module Spinach
       word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")
+      word.tr!(" ", "_")
       word.downcase!
       word
     end

--- a/test/spinach/support_test.rb
+++ b/test/spinach/support_test.rb
@@ -54,6 +54,10 @@ describe Spinach::Support do
     it 'accepts non string values' do
       Spinach::Support.underscore(:FeatureName).must_equal 'feature_name'
     end
+
+    it 'changes spaces to underscores' do
+      Spinach::Support.underscore('feature name').must_equal 'feature_name'
+    end
   end
 
   describe "#escape" do


### PR DESCRIPTION
Right now methods are created with spaces:

```
def "i close a task"
end
```

I want to change it to:

```
def i_close_a_task
end
```

So, in the case anyone wants, you can write feature steps with:

```
def i_close_a_task
end
```

Instead of:

```
When "I close a task" do
end
```

What do you think?
