### PR TITLE
Do not depend on 'tmp' existence

### DIFF
--- a/test/support/filesystem.rb
+++ b/test/support/filesystem.rb
@@ -3,7 +3,7 @@ require "fileutils"
 module Filesystem
   def in_current_dir(&block)
     dir = "tmp/fs"
-    FileUtils.mkdir(dir)
+    FileUtils.mkdir_p(dir)
     Dir.chdir(dir, &block)
   ensure
     FileUtils.rm_rf(dir)


### PR DESCRIPTION
Always create the tmp structure and zap it later.

This solves build failure caused in pull #101
