### PR TITLE
Added include to shared steps example in Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -162,6 +162,8 @@ This is one way to make that reusable:
 # ... features/steps/common_steps/login.rb
 module CommonSteps
   module Login
+    include Spinach::DSL
+    
     step 'I am logged in' do
       # log in stuff...
     end


### PR DESCRIPTION
The example of the shared steps does not work with the current version of Spinach without the inclusion of the Spinach::DSL module.
