### PR TITLE
Allow blockless step definitions

### DIFF
--- a/features/reporting/pending_feature_reporting.feature
+++ b/features/reporting/pending_feature_reporting.feature
@@ -8,3 +8,9 @@ Feature: Pending feature reporting
     When I run spinach
     Then I should see a message telling me that there's a pending scenario
     And I should see a message showing me the reason of the pending scenario
+ 
+ Scenario: Step definition without body
+    Given I've written a step definition without body
+    When I run spinach
+    Then I should see a message telling me that there's a pending scenario
+    And I should see a message showing me the default reason of the pending scenario

--- a/features/steps/reporting/pending_feature_reporting.rb
+++ b/features/steps/reporting/pending_feature_reporting.rb
@@ -24,6 +24,29 @@ class PendingFeatureReporting < Spinach::FeatureSteps
            pending "This step is pending."
          end
        end')
+
+    @feature = "features/pending_feature.feature"
+  end
+
+  Given "I've written a step definition without body" do
+    write_file(
+      'features/pending_feature.feature',
+      """
+      Feature: A pending feature
+
+      Scenario: This scenario is pending 
+        Given this is also a pending step
+      """)
+
+    write_file(
+      'features/steps/pending_feature.rb',
+      'class APendingFeature < Spinach::FeatureSteps
+
+         feature "A pending feature"
+
+         Given "this is also a pending step"
+       end')
+
     @feature = "features/pending_feature.feature"
   end
 
@@ -38,4 +61,9 @@ class PendingFeatureReporting < Spinach::FeatureSteps
   And "I should see a message showing me the reason of the pending scenario" do
     @stderr.must_include("This step is pending")
   end
+
+  And "I should see a message showing me the default reason of the pending scenario" do
+    @stderr.must_include("step not implemented")
+  end
+
 end

--- a/lib/spinach/dsl.rb
+++ b/lib/spinach/dsl.rb
@@ -26,6 +26,7 @@ module Spinach
       #
       # @param [Proc] block
       #   Action to perform in that step.
+      #   If no block is given, step will be defined as pending.
       #
       # @example
       #   These 3 examples are equivalent:
@@ -50,7 +51,11 @@ module Spinach
       #
       # @api public
       def step(step, &block)
-        define_method(Spinach::Support.underscore(step), &block)
+        method_body = if block_given? then block
+                      else lambda { pending "step not implemented" }
+                      end
+
+        define_method(Spinach::Support.underscore(step), &method_body)
       end
 
       alias_method :Given, :step


### PR DESCRIPTION
This imports the functionality from Minitest or Rspec
where you can mark the steps as pending by leaving them without
a block, like so:

``` ruby
describe Thingy do
  it "should do what things do"
end
```

Also, thanks for the great gem! I :heart: it!
