### PR TITLE
Fix tests

### DIFF
--- a/test/spinach/runner_test.rb
+++ b/test/spinach/runner_test.rb
@@ -151,7 +151,7 @@ describe Spinach::Runner do
         ['features/steps/a.rb', 'features/steps/a/a.rb', 'features/steps/z.rb', 'features/steps/z/z.rb'].each do |f|
           FileUtils.touch(f)
         end
-        runner.required_files.must_equal(['features/steps/a/a.rb', 'features/steps/z/z.rb', 'features/steps/a.rb', 'features/steps/z.rb'])
+        runner.required_files.must_equal(['/features/steps/a/a.rb', '/features/steps/z/z.rb', '/features/steps/a.rb', '/features/steps/z.rb'])
       end
     end
 


### PR DESCRIPTION
This is a very subtle bug between FakeFS and minitest: If the must_equal
comparison fails, it opens a temp file and within FakeFS block, tempfile
opening will fail. So the fix would be to fix the test, and apparently,
with new FakeFS, a leading "/" is required
