### PR TITLE
Include description lines from feature files in a 'description_lines' at...

### DIFF
--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -3,6 +3,7 @@ module Spinach
     attr_accessor :line
     attr_accessor :name, :scenarios, :tags
     attr_accessor :background
+    attr_accessor :description
 
     def initialize
       @scenarios = []

--- a/lib/spinach/parser/visitor.rb
+++ b/lib/spinach/parser/visitor.rb
@@ -37,6 +37,7 @@ module Spinach
       # @api public
       def visit_Feature(node)
         @feature.name = node.name
+        @feature.description = node.description
         node.background.accept(self) if node.background
 
         @current_tag_set = @feature

--- a/test/spinach/parser/visitor_test.rb
+++ b/test/spinach/parser/visitor_test.rb
@@ -29,6 +29,7 @@ module Spinach
           @node  = stub(
             scenarios: @scenarios,
             name: 'Go shopping',
+            description: ['some non-interpreted info','from the description'],
             background: @background,
             tags: @tags
           )
@@ -37,6 +38,11 @@ module Spinach
         it 'sets the name' do
           visitor.visit_Feature(@node)
           visitor.feature.name.must_equal 'Go shopping'
+        end
+
+        it 'sets the description' do
+          visitor.visit_Feature(@node)
+          visitor.feature.description.must_equal ['some non-interpreted info','from the description']
         end
 
         it 'sets the tags' do

--- a/test/spinach/parser_test.rb
+++ b/test/spinach/parser_test.rb
@@ -4,6 +4,9 @@ describe Spinach::Parser do
   before do
     @contents = """
 Feature: User authentication
+  As a developer
+  I expect some stuff
+  So that I have it
 
   Scenario: User logs in
     Given I am on the front page
@@ -22,6 +25,11 @@ Feature: User authentication
       visitor.expects(:visit).with ast
       @parser.parse
     end
+
+    it 'includes description text in the feature' do
+      feature = @parser.parse
+      feature.description.must_equal ['As a developer', 'I expect some stuff', 'So that I have it']
+    end
   end
 
   describe '.open_file' do
@@ -31,4 +39,5 @@ Feature: User authentication
         'feature_definition.feature')
     end
   end
+
 end


### PR DESCRIPTION
...tribute of Feature

My team would like to include the description from feature files as part of our test report. I've written a custom reporter for our test suite, and would like to use Spinach Feature instances to directly access the description as parsed by Gherkin. This change adds a 'description_lines' attribute to Feature, updates the AST visitor to set that attribute with the value from the Gherkin parser-generated feature node, and includes tests to cover the changes.
