### PR TITLE
set red color to undefined step/feature messages

### DIFF
--- a/lib/spinach/reporter/reporting.rb
+++ b/lib/spinach/reporter/reporting.rb
@@ -34,7 +34,7 @@ module Spinach
       def report_undefined_steps
         if undefined_steps.any?
           error.puts "\nUndefined steps summary:\n"
-          report_errors('Undefined steps', undefined_steps, :yellow)
+          report_errors('Undefined steps', undefined_steps, :red)
         end
       end
 
@@ -47,9 +47,9 @@ module Spinach
 
       def report_undefined_features
         if undefined_features.any?
-          error.puts "  Undefined features (#{undefined_features.length})".light_yellow
+          error.puts "  Undefined features (#{undefined_features.length})".red
           undefined_features.each do |feature|
-            error.puts "    #{feature.name}".yellow
+            error.puts "    #{feature.name}".red
           end
         end
       end
@@ -108,7 +108,7 @@ module Spinach
         feature, scenario, step, exception = error
         summary = "    #{feature.name} :: #{scenario.name} :: #{full_step step}"
         if exception.kind_of?(Spinach::StepNotDefinedException)
-          summary.yellow
+          summary.red
         elsif exception.kind_of?(Spinach::StepPendingException)
           summary += "\n      Reason: '#{exception.reason}'\n"
           summary.yellow
@@ -133,10 +133,10 @@ module Spinach
 
         if exception.kind_of?(Spinach::StepNotDefinedException)
           output << "\n"
-          output << "        You can define it with: \n\n".yellow
+          output << "        You can define it with: \n\n".red
           suggestion = Generators::StepGenerator.new(step).generate
           suggestion.split("\n").each do |line|
-            output << "          #{line}\n".yellow
+            output << "          #{line}\n".red
           end
           output << "\n"
         elsif exception.kind_of?(Spinach::StepPendingException)
@@ -169,7 +169,7 @@ module Spinach
         }.join("\n")
 
         if exception.kind_of?(Spinach::StepNotDefinedException)
-          output.yellow
+          output.red
         elsif exception.kind_of?(Spinach::StepPendingException)
           output.yellow
         else
@@ -215,7 +215,7 @@ module Spinach
       #
       def run_summary
         successful_summary = format_summary(:green,  successful_steps, 'Successful')
-        undefined_summary  = format_summary(:yellow, undefined_steps,  'Undefined')
+        undefined_summary  = format_summary(:red,    undefined_steps,  'Undefined')
         pending_summary    = format_summary(:yellow, pending_steps,    'Pending')
         failed_summary     = format_summary(:red,    failed_steps,     'Failed')
         error_summary      = format_summary(:red,    error_steps,      'Error')

--- a/lib/spinach/reporter/stdout.rb
+++ b/lib/spinach/reporter/stdout.rb
@@ -102,7 +102,7 @@ module Spinach
       #   The step in a JSON GherkinRubyRuby format
       #
       def on_undefined_step(step, failure, step_definitions = nil)
-        output_step('?', step, :yellow)
+        output_step('?', step, :red)
         self.scenario_error = [current_feature, current_scenario, step, failure]
         undefined_steps << scenario_error
       end
@@ -134,7 +134,7 @@ module Spinach
         lines << generator.generate
 
         lines.split("\n").each do |line|
-          out.puts "    #{line}".yellow
+          out.puts "    #{line}".red
         end
         out.puts "\n\n"
 

--- a/test/spinach/reporter/stdout/error_reporting_test.rb
+++ b/test/spinach/reporter/stdout/error_reporting_test.rb
@@ -97,7 +97,7 @@ describe Spinach::Reporter::Stdout do
       it 'outputs the failing steps' do
         steps = [anything]
         @reporter.stubs(:undefined_steps).returns(steps)
-        @reporter.expects(:report_errors).with('Undefined steps', steps, :yellow)
+        @reporter.expects(:report_errors).with('Undefined steps', steps, :red)
 
         @reporter.report_undefined_steps
       end
@@ -220,11 +220,11 @@ describe Spinach::Reporter::Stdout do
     end
 
     describe 'when given an undefined step exception' do
-      it 'prints the error in yellow' do
+      it 'prints the error in red' do
         undefined_error = error
         undefined_error.insert(3, Spinach::StepNotDefinedException.new(anything))
 
-        String.any_instance.expects(:yellow)
+        String.any_instance.expects(:red)
 
         @reporter.summarized_error(error)
       end
@@ -292,10 +292,10 @@ describe Spinach::Reporter::Stdout do
     end
 
     describe 'when given an undefined step exception' do
-      it 'prints the error in yellow' do
+      it 'prints the error in red' do
         undefined_exception = Spinach::StepNotDefinedException.new(stub(name: 'some step'))
 
-        String.any_instance.expects(:yellow)
+        String.any_instance.expects(:red)
 
         @reporter.report_exception(undefined_exception)
       end


### PR DESCRIPTION
When there are undefined features or steps, the build is marked as failed, but the color of the undefined stuff appears as yellow. 

I think is more understandable if the undefined messages appears in red.
