### PR TITLE
Steps Summary: change order of summaries.

### DIFF
--- a/lib/spinach/reporter/reporting.rb
+++ b/lib/spinach/reporter/reporting.rb
@@ -220,7 +220,7 @@ module Spinach
         failed_summary     = format_summary(:red,    failed_steps,     'Failed')
         error_summary      = format_summary(:red,    error_steps,      'Error')
 
-        out.puts "Steps Summary: #{successful_summary}, #{undefined_summary}, #{pending_summary}, #{failed_summary}, #{error_summary}\n\n"
+        out.puts "Steps Summary: #{successful_summary}, #{pending_summary}, #{undefined_summary}, #{failed_summary}, #{error_summary}\n\n"
         out.puts "Finished in #{Time.now - @start_time} seconds" if @start_time
       end
     end


### PR DESCRIPTION
This PR changes the order of the summary messages.

Right now we have
Steps Summary: (1) Successful, (0) Undefined, (0) Pending, (0) Failed, (1) Error

I am proposing to swap Undefined and pending so we have that from the left side to the right is means from the best result to the worst.
