### PR TITLE
Use alias_method instead of method_missing

### DIFF
--- a/lib/spinach/capybara.rb
+++ b/lib/spinach/capybara.rb
@@ -17,31 +17,24 @@ module Spinach
     #   end
     #
     module Capybara
-      class CapybaraDslDelegator
-        include ::Capybara::DSL
-        if defined?(RSpec)
-          require 'rspec/matchers'
-          require 'capybara/rspec'
-          include ::Capybara::RSpecMatchers
-        end
+      include ::Capybara::DSL
+
+      if defined?(RSpec)
+        require 'rspec/matchers'
+        require 'capybara/rspec'
+        include ::Capybara::RSpecMatchers
       end
+
+      alias_method :capybara_visit, :visit
 
       def visit(*args)
         stream = STDOUT
         old_stream = stream.dup
         stream.reopen(null_device)
         stream.sync = true
-        instance.visit *args
+        capybara_visit *args
       ensure
         stream.reopen(old_stream)
-      end
-
-      def instance
-        @instance ||= CapybaraDslDelegator.new
-      end
-
-      def method_missing(m, *args)
-        instance.send m, *args
       end
 
       def null_device

--- a/test/spinach/capybara_test.rb
+++ b/test/spinach/capybara_test.rb
@@ -59,7 +59,7 @@ Feature: A test feature
   }
 
   it 'responds to Capybara::DSL methods' do
-    @feature.respond_to?(:page).must_equal false
+    @feature.respond_to?(:page).must_equal true
   end
 
   it 'does not respond to non Capybara::DSL methods' do


### PR DESCRIPTION
Fixes https://github.com/codegram/spinach/issues/156

The method_missing seemed unnecessary, so I added an alias_method to override the `visit` method behaviour.
