### PR TITLE
Support subdirectories when generating features

### DIFF
--- a/lib/spinach/generators/feature_generator.rb
+++ b/lib/spinach/generators/feature_generator.rb
@@ -49,9 +49,11 @@ module Spinach
       # @return [String]
       #   an example filename for this feature steps
       def filename
-        Spinach::Support.underscore(
-          Spinach::Support.camelize name
-        ) + ".rb"
+        name.split('/').map do |segment|
+          Spinach::Support.underscore(
+            Spinach::Support.camelize segment
+          )
+        end.join('/') + '.rb'
       end
 
       # @return [String]
@@ -72,7 +74,7 @@ module Spinach
         if File.exists?(filename_with_path)
           raise FeatureGeneratorException.new("File #{filename_with_path} already exists.")
         else
-          FileUtils.mkdir_p path
+          FileUtils.mkdir_p File.dirname(filename_with_path)
           File.open(filename_with_path, 'w') do |file|
             file.write(generate)
             puts "Generating #{File.basename(filename_with_path)}"


### PR DESCRIPTION
I always organise my features into directories but currently spinach doesn't support this, when they're generated they're always placed in the root features folder. This patch will let you use a slash in the feature name to specify a directory e.g.

Feature: admins/Role management

```
$ spinach --generate
$ ls features/steps/admin/
role_management.rb
```

I haven't added a test yet, thought I'd see if you're open to the idea first. I did consider taking the folder from the file path of the feature file but this is a bit awkward because the parser that generates the feature doesn't know anything about the file (just the content).
