### PR TITLE
Detect existing features in subfolders

### DIFF
--- a/lib/spinach/generators/feature_generator.rb
+++ b/lib/spinach/generators/feature_generator.rb
@@ -70,7 +70,7 @@ module Spinach
       #
       def store
         if file_exists?(filename)
-          raise FeatureGeneratorException.new("File #{file_path(filename)} already exists.")
+          raise FeatureGeneratorException.new("File #{filename} already exists at #{file_path(filename)}.")
         else
           FileUtils.mkdir_p path
           File.open(filename_with_path, 'w') do |file|


### PR DESCRIPTION
This is an alternative to https://github.com/codegram/spinach/pull/159. 

This patches the feature generator to check for an existing implementations of a feature file in subdirectories of steps e.g.

Given a feature at

```
features/analytics/admin_analytics.feature
```

and an implementation at

```
features/steps/analytics/admin_analytics.rb
```

when you run

```
$ spinach --generate
```

then a new file will _not_ be generated at:

```
features/steps/admin_analytics.rb
```
