### PR TITLE
Support multiple lines in feature file CLI syntax

### DIFF
--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -1,6 +1,6 @@
 module Spinach
   class Feature
-    attr_accessor :filename, :line
+    attr_accessor :filename, :lines
     attr_accessor :name, :scenarios, :tags
     attr_accessor :background
     attr_accessor :description
@@ -14,8 +14,8 @@ module Spinach
       @background.nil? ? [] : @background.steps
     end
 
-    def line=(value)
-      @line = value.to_i if value
+    def lines=(value)
+      @lines = value.map(&:to_i) if value
     end
   end
 end

--- a/test/spinach/cli_test.rb
+++ b/test/spinach/cli_test.rb
@@ -257,6 +257,15 @@ tags:
       end
     end
 
+    describe "when a particular feature list is passed with multiple lines" do
+      it "returns the feature with the line numbers" do
+        cli = Spinach::Cli.new(['features/some_feature.feature:10:20'])
+        File.stubs(:exists?).returns(true)
+
+        cli.feature_files.must_equal ["features/some_feature.feature:10:20"]
+      end
+    end
+
     describe 'when no feature is passed' do
       it 'returns all the features' do
         cli = Spinach::Cli.new([])


### PR DESCRIPTION
This allows spinach to support a CLI syntax like:

```
spinach features/cool_feature.feature:10:20:30:40
```

Currently, passing a feature file argument as above would cause only the scenario on line 10 to run.