### PR TITLE
Don't redirect stdout before calling Capybara's `visit` method

### DIFF
--- a/lib/spinach/capybara.rb
+++ b/lib/spinach/capybara.rb
@@ -24,30 +24,6 @@ module Spinach
         require 'capybara/rspec'
         include ::Capybara::RSpecMatchers
       end
-
-      alias_method :capybara_visit, :visit
-
-      def visit(*args)
-        stream = STDOUT
-        old_stream = stream.dup
-        stream.reopen(null_device)
-        stream.sync = true
-        capybara_visit *args
-      ensure
-        stream.reopen(old_stream)
-      end
-
-      def null_device
-        return @null_device if defined?(@null_device)
-
-        if RbConfig::CONFIG["host_os"] =~ /mingw|mswin/
-          @null_device = "NUL"
-        else
-          @null_device = "/dev/null"
-        end
-
-        @null_device
-      end
     end
   end
 end


### PR DESCRIPTION
Redirecting stdout breaks using a debugging tool like `pry` from a controller action. Here's a [small example](https://github.com/kylesmile/spinach_pry_bug).

I'm not sure if there's a good way to write a test for this, but suggestions are welcome.