### PR TITLE
Tighten exception catching when running scenarios

### DIFF
--- a/lib/spinach/runner/scenario_runner.rb
+++ b/lib/spinach/runner/scenario_runner.rb
@@ -86,7 +86,7 @@ module Spinach
         e.step = step
         @has_pending_step = true
         Spinach.hooks.run_on_pending_step step, e
-      rescue Exception => e
+      rescue StandardError => e
         @exception = e
         Spinach.hooks.run_on_error_step step, @exception, step_location, step_definitions
       end

--- a/test/spinach/capybara_test.rb
+++ b/test/spinach/capybara_test.rb
@@ -26,7 +26,7 @@ describe Spinach::FeatureSteps::Capybara do
       Then 'Goodbye' do
       end
       Given 'Fail' do
-        1.must_equal 2
+        raise StandardError
       end
       def go_home
         visit '/'


### PR DESCRIPTION
Rescuing Exception makes it difficult to kill Spinach mid-run - <kbd>ctrl</kbd>-<kbd>c</kbd> is caught and handled as a scenario error. This is frustrating, since attempting to interrupt a test suite will result in continued output to the terminal until the run finishes.

I couldn't think of a reason to rescue `Exception` here so I tightened it to `StandardError`, which most dev-facing exceptions should inherit from.