### PR TITLE
Add a --audit flag for finding missing/unused steps

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -181,6 +181,29 @@ class Spinach::Features::BuyAWidget < Spinach::FeatureSteps
 end
 ```
 
+## Audit
+
+Over time, the definitions of your features will change. When you add, remove
+or change steps in the feature files, you can easily audit your existing step 
+files with:
+
+```shell
+$ spinach --audit
+```
+
+This will find any new steps and print out boilerplate for them, and alert you
+to the filename and line number of any unused steps in your step files.
+
+This does not modify the step files, so you will need to paste the boilerplate
+into the appropriate places. If a new feature file is detected, you will be
+asked to run `spinach --generate` beforehand.
+
+**Important**: If auditing individual files, common steps (as above) may be 
+reported as unused when they are actually used in a feature file that is not 
+currently being audited. To avoid this, run the audit with no arguments to
+audit all step files simultaneously.
+
+
 ## Tags
 
 Feature and Scenarios can be marked with tags in the form: `@tag`. Tags can be

--- a/features/step_auditing.feature
+++ b/features/step_auditing.feature
@@ -20,3 +20,5 @@ Feature: Step auditing
     
   #Scenario: Tells the user to generate if step file missing
   
+  #Scenario: Steps still marked unused if they appear in the wrong file
+  

--- a/features/step_auditing.feature
+++ b/features/step_auditing.feature
@@ -7,7 +7,7 @@ Feature: Step auditing
     Given I have defined a "Cheezburger can I has" feature
     And I have an associated step file with missing steps and obsolete steps
     When I run spinach with "--audit"
-    Then I should see a list of obsolete steps
+    Then I should see a list of unused steps
     And I should see the code to paste for missing steps
     
   Scenario: With common steps
@@ -16,4 +16,7 @@ Feature: Step auditing
     When I run spinach with "--audit"
     Then I should not see the common steps marked as missing
   
+  #Scenario: Steps not marked unused if they're used in at least one feature
     
+  #Scenario: Tells the user to generate if step file missing
+  

--- a/features/step_auditing.feature
+++ b/features/step_auditing.feature
@@ -18,11 +18,18 @@ Feature: Step auditing
   
   Scenario: Steps not marked unused if they're in common modules
     Given I have defined a "Cheezburger can I has" feature
+    And I have defined an "Awesome new feature" feature
     And I have associated step files with common steps that are all used somewhere
     When I run spinach with "--audit"
     Then I should not see any steps marked as unused
     
-  #Scenario: Common steps are reported as missing if not used by any feature
+  Scenario: Common steps are reported as missing if not used by any feature
+    Given I have defined a "Cheezburger can I has" feature
+    And I have defined an "Awesome new feature" feature
+    And I have step files for both with common steps, but one common step is not used by either
+    When I run spinach with "--audit"
+    Then I should be told the extra step is unused
+    But I should not be told the other common steps are unused
     
   Scenario: Tells the user to generate if step file missing
     Given I have defined a "Cheezburger can I has" feature

--- a/features/step_auditing.feature
+++ b/features/step_auditing.feature
@@ -1,0 +1,19 @@
+Feature: Step auditing
+  In order to be able to update my features
+  As a developer
+  I want spinach to automatically audit which steps are missing and obsolete
+  
+  Scenario: Step file out of date
+    Given I have defined a "Cheezburger can I has" feature
+    And I have an associated step file with missing steps and obsolete steps
+    When I run spinach with "--audit"
+    Then I should see a list of obsolete steps
+    And I should see the code to paste for missing steps
+    
+  Scenario: With common steps
+    Given I have defined a "Cheezburger can I has" feature
+    And I have an associated step file with some steps in a common module
+    When I run spinach with "--audit"
+    Then I should not see the common steps marked as missing
+  
+    

--- a/features/step_auditing.feature
+++ b/features/step_auditing.feature
@@ -14,11 +14,39 @@ Feature: Step auditing
     Given I have defined a "Cheezburger can I has" feature
     And I have an associated step file with some steps in a common module
     When I run spinach with "--audit"
-    Then I should not see the common steps marked as missing
+    Then I should not see any steps marked as missing
   
-  #Scenario: Steps not marked unused if they're used in at least one feature
+  Scenario: Steps not marked unused if they're in common modules
+    Given I have defined a "Cheezburger can I has" feature
+    And I have associated step files with common steps that are all used somewhere
+    When I run spinach with "--audit"
+    Then I should not see any steps marked as unused
     
-  #Scenario: Tells the user to generate if step file missing
+  #Scenario: Common steps are reported as missing if not used by any feature
+    
+  Scenario: Tells the user to generate if step file missing
+    Given I have defined a "Cheezburger can I has" feature
+    And I have not created an associated step file
+    When I run spinach with "--audit"
+    Then I should be told to run "--generate"
   
-  #Scenario: Steps still marked unused if they appear in the wrong file
+  Scenario: Steps still marked unused if they appear in the wrong file
+    Given I have defined a "Cheezburger can I has" feature
+    And I have defined an "Awesome new feature" feature
+    And I have created a step file for each with a step from one feature pasted into the other's file
+    When I run spinach with "--audit"
+    Then I should be told that step is unused
   
+  Scenario: Reports a clean audit if no steps are missing
+    Given I have defined a "Cheezburger can I has" feature
+    And I have defined an "Awesome new feature" feature
+    And I have complete step files for both
+    When I run spinach with "--audit"
+    Then I should be told this was a clean audit
+
+  Scenario: Should not report a step as missing more than once
+    Given I have defined an "Exciting feature" feature with reused steps
+    And I have created a step file without those reused steps
+    When I run spinach with "--audit"
+    Then I should see the missing steps reported only once
+    

--- a/features/steps/step_auditing.rb
+++ b/features/steps/step_auditing.rb
@@ -43,13 +43,14 @@ end
   end
 
   step 'I should see the code to paste for missing steps' do
+    @stdout.must_match("Missing steps")
     @stdout.must_match("step 'I get some lulz' do")
     @stdout.must_match("step 'I cannot haz' do")
   end
 
   step 'I have an associated step file with some steps in a common module' do
     write_file('features/steps/cheezburger_can_i_has.rb', """
-class Spinach::Features::CheezburgerCanIHaz < Spinach::FeatureSteps
+class Spinach::Features::CheezburgerCanIHas < Spinach::FeatureSteps
   include HappySad
   step 'I get some roxxorz' do
     pending 'step not implemented'
@@ -71,13 +72,173 @@ end
 """)
   end
 
-  step 'I should not see the common steps marked as missing' do
-    @stdout.wont_match("step 'I haz a sad' do")
-    @stdout.wont_match("step 'I haz a happy' do")
+  step 'I should not see any steps marked as missing' do
+    @stdout.wont_match("Missing steps")
   end
   
-  step 'Deary me' do
-    puts "Oh dear"
+  step 'I should not see any steps marked as unused' do
+    @stdout.wont_match("Unused step")
+  end
+  
+  step 'I have defined an "Awesome new feature" feature' do
+    write_file('features/awesome_new_feature.feature', """
+  Feature: Awesome new feature
+    Scenario: Awesomeness
+      Given I am awesome
+      When I do anything
+      Then people will cheer
+  """)
+  end
+
+  step 'I have associated step files with common steps that are all used somewhere' do
+    write_file('features/steps/cheezburger_can_i_has.rb', """
+  class Spinach::Features::CheezburgerCanIHas < Spinach::FeatureSteps
+    include Awesome
+    step 'I haz a sad' do
+      pending 'step not implemented'
+    end
+    step 'I get some lulz' do
+      pending 'step not implemented'
+    end
+    step 'I wantz cheezburger' do
+      pending 'step not implemented'
+    end
+    step 'I ask can haz' do
+      pending 'step not implemented'
+    end
+    step 'I cannot haz' do
+      pending 'step not implemented'
+    end
+  end
+  """)
+    write_file('features/steps/awesome_new_feature.rb', """
+  class Spinach::Features::AwesomeNewFeature < Spinach::FeatureSteps
+    include Awesome
+    step 'I do anything' do
+      pending 'step not implemented'
+    end
+  end
+  """)
+    write_file('features/steps/awesome.rb', """
+  module Awesome
+    step 'I am awesome' do
+      pending 'step not implemented'
+    end
+    step 'people will cheer' do
+      pending 'step not implemented'
+    end
+    step 'I haz a happy' do
+      pending 'step not implemented'
+    end
+  end
+  """)
+  end
+
+  step 'I have not created an associated step file' do
+    # Do nothing
+  end
+
+  step 'I should be told to run "--generate"' do
+    @stdout.must_match("Step file missing: please run --generate first!")
+  end
+
+  step 'I have created a step file for each with a step from one feature pasted into the other\'s file' do    
+    write_file('features/steps/cheezburger_can_i_has.rb', """
+class Spinach::Features::CheezburgerCanIHas < Spinach::FeatureSteps
+  step 'I haz a sad' do
+    pending 'step not implemented'
+  end
+  step 'I get some lulz' do
+    pending 'step not implemented'
+  end
+  step 'I haz a happy' do
+    pending 'step not implemented'
+  end
+  step 'I wantz cheezburger' do
+    pending 'step not implemented'
+  end
+  step 'I ask can haz' do
+    pending 'step not implemented'
+  end
+  step 'I cannot haz' do
+    pending 'step not implemented'
+  end
+end
+""")
+    write_file('features/steps/awesome_new_feature.rb', """
+class Spinach::Features::AwesomeNewFeature < Spinach::FeatureSteps
+  step 'I am awesome' do
+    pending 'step not implemented'
+  end
+  step 'I do anything' do
+    pending 'step not implemented'
+  end
+  step 'people will cheer' do
+    pending 'step not implemented'
+  end
+  step 'I haz a happy' do
+    pending 'step not implemented'
+  end
+end
+""")
+  end
+
+  step 'I should be told that step is unused' do
+    @stdout.must_match(/Unused step: .*awesome_new_feature.rb:12 'I haz a happy'/)
+  end
+
+  step 'I have complete step files for both' do
+    write_file('features/steps/cheezburger_can_i_has.rb', """
+class Spinach::Features::CheezburgerCanIHas < Spinach::FeatureSteps
+  step 'I haz a sad' do
+    pending 'step not implemented'
+  end
+  step 'I get some lulz' do
+    pending 'step not implemented'
+  end
+  step 'I haz a happy' do
+    pending 'step not implemented'
+  end
+  step 'I wantz cheezburger' do
+    pending 'step not implemented'
+  end
+  step 'I ask can haz' do
+    pending 'step not implemented'
+  end
+  step 'I cannot haz' do
+    pending 'step not implemented'
+  end
+end
+""")
+    write_file('features/steps/awesome_new_feature.rb', """
+class Spinach::Features::AwesomeNewFeature < Spinach::FeatureSteps
+  step 'I am awesome' do
+    pending 'step not implemented'
+  end
+  step 'I do anything' do
+    pending 'step not implemented'
+  end
+  step 'people will cheer' do
+    pending 'step not implemented'
+  end
+end
+""")
+  end
+
+  step 'I should be told this was a clean audit' do
+    @stdout.must_match('Audit clean - no missing steps.')
+  end
+
+  step 'I have defined an "Exciting feature" feature with reused steps' do
+    pending 'step not implemented'
+  end
+
+  step 'I have created a step file without those reused steps' do
+    pending 'step not implemented'
+  end
+
+  step 'I should see the missing steps reported only once' do
+    pending 'step not implemented'
   end
   
 end

--- a/features/steps/step_auditing.rb
+++ b/features/steps/step_auditing.rb
@@ -317,4 +317,8 @@ end
     @stdout.wont_match('I haz a happy')
   end
   
+  step 'bad' do
+    pending 'hello'
+  end
+  
 end

--- a/features/steps/step_auditing.rb
+++ b/features/steps/step_auditing.rb
@@ -17,7 +17,7 @@ Feature: Cheezburger can I has
   
   step 'I have an associated step file with missing steps and obsolete steps' do
     write_file('features/steps/cheezburger_can_i_has.rb', """
-class Spinach::Features::CheezburgerCanIHaz < Spinach::FeatureSteps
+class Spinach::Features::CheezburgerCanIHas < Spinach::FeatureSteps
   step 'I haz a sad' do
     pending 'step not implemented'
   end
@@ -38,8 +38,8 @@ end
     run_feature 'features/cheezburger_can_i_has.feature', append: '--audit'
   end
 
-  step 'I should see a list of obsolete steps' do
-    @stdout.must_match("Obsolete step: step_auditing.rb:24 'I get some roxxorz'")
+  step 'I should see a list of unused steps' do
+    @stdout.must_match(/Unused step: .*cheezburger_can_i_has.rb:6 'I get some roxxorz'/)
   end
 
   step 'I should see the code to paste for missing steps' do
@@ -75,4 +75,9 @@ end
     @stdout.wont_match("step 'I haz a sad' do")
     @stdout.wont_match("step 'I haz a happy' do")
   end
+  
+  step 'Deary me' do
+    puts "Oh dear"
+  end
+  
 end

--- a/features/steps/step_auditing.rb
+++ b/features/steps/step_auditing.rb
@@ -1,0 +1,78 @@
+class Spinach::Features::StepAuditing < Spinach::FeatureSteps
+  
+  include Integration::SpinachRunner
+  step 'I have defined a "Cheezburger can I has" feature' do
+    write_file('features/cheezburger_can_i_has.feature', """
+Feature: Cheezburger can I has
+  Scenario: Some Lulz
+    Given I haz a sad
+    When I get some lulz
+    Then I haz a happy
+  Scenario: Cannot haz
+    Given I wantz cheezburger
+    When I ask can haz
+    Then I cannot haz
+""")
+  end
+  
+  step 'I have an associated step file with missing steps and obsolete steps' do
+    write_file('features/steps/cheezburger_can_i_has.rb', """
+class Spinach::Features::CheezburgerCanIHaz < Spinach::FeatureSteps
+  step 'I haz a sad' do
+    pending 'step not implemented'
+  end
+  step 'I get some roxxorz' do
+    pending 'step not implemented'
+  end
+  step 'I haz a happy' do
+    pending 'step not implemented'
+  end
+  step 'I ask can haz' do
+    pending 'step not implemented'
+  end
+end
+""")    
+  end
+
+  step 'I run spinach with "--audit"' do
+    run_feature 'features/cheezburger_can_i_has.feature', append: '--audit'
+  end
+
+  step 'I should see a list of obsolete steps' do
+    @stdout.must_match("Obsolete step: step_auditing.rb:24 'I get some roxxorz'")
+  end
+
+  step 'I should see the code to paste for missing steps' do
+    @stdout.must_match("step 'I get some lulz' do")
+    @stdout.must_match("step 'I cannot haz' do")
+  end
+
+  step 'I have an associated step file with some steps in a common module' do
+    write_file('features/steps/cheezburger_can_i_has.rb', """
+class Spinach::Features::CheezburgerCanIHaz < Spinach::FeatureSteps
+  include HappySad
+  step 'I get some roxxorz' do
+    pending 'step not implemented'
+  end
+  step 'I ask can haz' do
+    pending 'step not implemented'
+  end
+end
+""")
+    write_file('features/steps/happy_sad.rb', """
+module HappySad
+  step 'I haz a sad' do
+    pending 'step not implemented'
+  end
+  step 'I haz a happy' do
+    pending 'step not implemented'
+  end
+end
+""")
+  end
+
+  step 'I should not see the common steps marked as missing' do
+    @stdout.wont_match("step 'I haz a sad' do")
+    @stdout.wont_match("step 'I haz a happy' do")
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,6 +16,6 @@ if ENV['CI'] && !defined?(Rubinius)
 end
 
 
-Spinach.hooks.after_run do |scenario|
+Spinach.hooks.after_scenario do |scenario|
   FileUtils.rm_rf(Filesystem.dirs)
 end

--- a/lib/spinach.rb
+++ b/lib/spinach.rb
@@ -11,6 +11,7 @@ require_relative 'spinach/feature_steps'
 require_relative 'spinach/reporter'
 require_relative 'spinach/cli'
 require_relative 'spinach/generators'
+require_relative 'spinach/auditor'
 
 require_relative 'spinach/background'
 require_relative 'spinach/feature'

--- a/lib/spinach/auditor.rb
+++ b/lib/spinach/auditor.rb
@@ -1,0 +1,52 @@
+require 'pry'
+
+module Spinach
+  # The auditor audits steps and determines if any are missing or obsolete.
+  #
+  # It is a subclass of Runner because it uses many of the Runner's features
+  # when auditing.
+  #
+  class Auditor < Runner
+    # audits features
+    # @files [Array]
+    #   filenames to audit
+    def run
+      require_dependencies
+      
+      filenames.each do |file|        
+        feature = Parser.open_file(file).parse
+        step_defs_class = Spinach.find_step_definitions(feature.name)
+        if !step_defs_class
+          puts "No definitions!"
+          next
+        end
+        step_defs = step_defs_class.new        
+        step_names = step_defs_class.steps
+                        
+        feature.scenarios.each do |scenario|
+          scenario.steps.each do |step|
+            method_name = Spinach::Support.underscore step.name
+            if step_defs.respond_to?(method_name)
+              puts "Found step '#{step.name}'"
+            else
+              puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ')
+            end
+            step_names.delete step.name # we've audited this step
+          end
+        end
+        
+        # If there are any steps left at the end, let's mark them as obsolete
+        step_names.each do |obsolete_name|
+          location = []
+          begin
+            location = step_defs.method(Spinach::Support.underscore obsolete_name).source_location
+          rescue NameError
+            # if the method doesn't exist, just leave location as empty
+          end
+          puts "Unused step: #{location.join ':'} '#{obsolete_name}'"
+        end
+      end
+      true
+    end
+  end
+end

--- a/lib/spinach/auditor.rb
+++ b/lib/spinach/auditor.rb
@@ -7,46 +7,91 @@ module Spinach
   # when auditing.
   #
   class Auditor < Runner
+    
+    attr_accessor :unused_steps
+    
+    def initialize(filenames)
+      super(filenames)
+      @unused_steps = {}
+    end    
+    
     # audits features
     # @files [Array]
     #   filenames to audit
     def run
       require_dependencies
       
-      filenames.each do |file|        
-        feature = Parser.open_file(file).parse
-        step_defs_class = Spinach.find_step_definitions(feature.name)
-        if !step_defs_class
-          puts "No definitions!"
-          next
-        end
-        step_defs = step_defs_class.new        
-        step_names = step_defs_class.steps
-                        
-        feature.scenarios.each do |scenario|
-          scenario.steps.each do |step|
-            method_name = Spinach::Support.underscore step.name
-            if step_defs.respond_to?(method_name)
-              puts "Found step '#{step.name}'"
-            else
-              puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ')
-            end
-            step_names.delete step.name # we've audited this step
-          end
-        end
-        
-        # If there are any steps left at the end, let's mark them as obsolete
-        step_names.each do |obsolete_name|
-          location = []
-          begin
-            location = step_defs.method(Spinach::Support.underscore obsolete_name).source_location
-          rescue NameError
-            # if the method doesn't exist, just leave location as empty
-          end
-          puts "Unused step: #{location.join ':'} '#{obsolete_name}'"
-        end
+      # Find any missing steps in each file, and keep track of unused steps
+      clean = true
+      filenames.each do |file|
+        clean &&= audit_file(file)
       end
+
+      # At the end, report any unused steps      
+      report_unused_steps
+      
+      # If the audit was clean, make sure the user knows
+      if clean
+        puts "\nAudit clean - no missing steps.".colorize(:light_green)
+      end
+      
       true
     end
+    
+    private
+    
+    def audit_file(file)
+      puts "\nAuditing: ".colorize(:magenta) + file.colorize(:light_magenta)
+      
+      # Find the feature definition and its associated step defs class
+      feature = Parser.open_file(file).parse
+      step_defs_class = Spinach.find_step_definitions(feature.name)
+      if !step_defs_class
+        puts "  Step file missing: please run --generate first!".colorize(:light_red)
+        return
+      end
+      step_defs = step_defs_class.new        
+      unused_step_names = step_defs_class.steps
+      missing_steps = []
+                      
+      feature.scenarios.each do |scenario|
+        scenario.steps.each do |step|
+          method_name = Spinach::Support.underscore step.name
+          if step_defs.respond_to?(method_name)
+            # Do nothing for now
+            # FIXME: Remove unused steps
+          else
+            # OK - we can't find a step definition for this step
+            missing_steps << step
+          end
+          # Having audited the step, remove it from the list of unused steps
+          unused_step_names.delete step.name
+        end
+      end
+      
+      # If there are any steps left at the end, let's mark them as obsolete
+      unused_step_names.each do |name|
+        location = step_defs.step_location_for(name)
+        unused_steps[location.join ':'] = name
+      end
+      
+      # And then generate a report of missing steps
+      if missing_steps.length > 0
+        puts "\nMissing steps:".colorize(:light_cyan)
+        missing_steps.each do |step|        
+          puts "\n"+Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').colorize(:cyan)
+        end
+        return false
+      end
+      return true
+    end
+    
+    def report_unused_steps
+      unused_steps.each do |location, name|
+        puts "\n" + "Unused step: #{location} ".colorize(:yellow) + "'#{name}'".colorize(:light_yellow)
+      end
+    end
+    
   end
+  
 end

--- a/lib/spinach/auditor.rb
+++ b/lib/spinach/auditor.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Spinach
   # The auditor audits steps and determines if any are missing or obsolete.
   #
@@ -47,7 +45,7 @@ module Spinach
       feature = Parser.open_file(file).parse
       step_defs_class = Spinach.find_step_definitions(feature.name)
       if !step_defs_class
-        puts "  Step file missing: please run --generate first!".colorize(:light_red)
+        puts "Step file missing: please run --generate first!".colorize(:light_red)
         return
       end
       step_defs = step_defs_class.new        
@@ -61,8 +59,9 @@ module Spinach
             # Do nothing for now
             # FIXME: Remove unused steps
           else
-            # OK - we can't find a step definition for this step
-            missing_steps << step
+            # OK - we can't find a step definition for this step - add it to the missing steps
+            # unless there is already a missing step of the same name
+            missing_steps << step unless missing_steps.map(&:name).include?(step.name)
           end
           # Having audited the step, remove it from the list of unused steps
           unused_step_names.delete step.name
@@ -79,7 +78,7 @@ module Spinach
       if missing_steps.length > 0
         puts "\nMissing steps:".colorize(:light_cyan)
         missing_steps.each do |step|        
-          puts "\n"+Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').colorize(:cyan)
+          puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').colorize(:cyan)
         end
         return false
       end

--- a/lib/spinach/auditor.rb
+++ b/lib/spinach/auditor.rb
@@ -7,7 +7,6 @@ module Spinach
   # when auditing.
   #
   class Auditor < Runner
-
     attr_accessor :unused_steps, :used_steps
 
     def initialize(filenames)
@@ -33,9 +32,7 @@ module Spinach
       report_unused_steps
 
       # If the audit was clean, make sure the user knows
-      if clean
-        puts "\nAudit clean - no missing steps.".colorize(:light_green)
-      end
+      puts "\nAudit clean - no missing steps.".colorize(:light_green) if clean
 
       true
     end
@@ -46,68 +43,86 @@ module Spinach
       puts "\nAuditing: ".colorize(:magenta) + file.colorize(:light_magenta)
 
       # Find the feature definition and its associated step defs class
-      feature = Parser.open_file(file).parse
-      step_defs_class = Spinach.find_step_definitions(feature.name)
-      if !step_defs_class
-        puts "Step file missing: please run --generate first!".
-          colorize(:light_red)
-        return
-      end
-      step_defs = step_defs_class.new        
-      unused_step_names = step_defs_class.ancestors.
-        map { |a| a.respond_to?(:steps) ? a.steps : []  }.flatten
-      missing_steps = []
+      feature, step_defs_class = get_feature_and_defs(file)
+      return step_file_missing if step_defs_class.nil?
+      step_defs = step_defs_class.new
+      unused_step_names = step_names_for_class(step_defs_class)
 
-      feature.scenarios.each do |scenario|
-        scenario.steps.each do |step|
-          method_name = Spinach::Support.underscore step.name
-          if step_defs.respond_to?(method_name)
-            # Remember the location so we can subtract from unused_steps 
-            # at the end
-            location = step_defs.step_location_for(step.name).join(':')
-            used_steps << location
-          else
-            # OK - we can't find a step definition for this step - add it to
-            # the missing steps unless there is already a missing step of the 
-            # same name
-            unless missing_steps.map(&:name).include?(step.name)
-              missing_steps << step
-            end
-          end
-          # Having audited the step, remove it from the list of unused steps
-          unused_step_names.delete step.name
-        end
+      missing_steps = {}
+
+      feature.each_step do |step|
+        # Audit the step
+        missing_steps[step.name] = step if step_missing?(step, step_defs)
+        # Having audited the step, remove it from the list of unused steps
+        unused_step_names.delete step.name
       end
 
       # If there are any steps left at the end, let's mark them as unused
-      unused_step_names.each do |name|
+      store_unused_steps(unused_step_names, step_defs)
+
+      # And then generate a report of missing steps
+      return true if missing_steps.empty?
+      report_missing_steps(missing_steps.values)
+      false
+    end
+
+    # Get the feature and its definitions from the appropriate files
+    def get_feature_and_defs(file)
+      feature = Parser.open_file(file).parse
+      [feature, Spinach.find_step_definitions(feature.name)]
+    end
+
+    # Process a step from the feature file using the given step_defs.
+    # If it is missing, return true. Otherwise, add it to the used_steps for
+    # the report at the end and return false.
+    def step_missing?(step, step_defs)
+      method_name = Spinach::Support.underscore step.name
+      return true unless step_defs.respond_to?(method_name)
+      # Remember that we have used this step
+      used_steps << step_defs.step_location_for(step.name).join(':')
+      false
+    end
+
+    # Store any unused step names for the report at the end of the audit
+    def store_unused_steps(names, step_defs)
+      names.each do |name|
         location = step_defs.step_location_for(name).join(':')
         unused_steps[location] = name
       end
-
-      # And then generate a report of missing steps
-      if missing_steps.empty?
-        return true
-      else
-        puts "\nMissing steps:".colorize(:light_cyan)
-        missing_steps.each do |step|
-          puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').
-            colorize(:cyan)
-        end
-        return false
-      end
     end
 
+    # Print a message alerting the user that there is no step file for this
+    # feature
+    def step_file_missing
+      puts 'Step file missing: please run --generate first!'
+        .colorize(:light_red)
+      false
+    end
+
+    # Get the step names for all steps in the given class, including those in
+    # common modules
+    def step_names_for_class(klass)
+      klass.ancestors.map { |a| a.respond_to?(:steps) ? a.steps : [] }.flatten
+    end
+
+    # Produce a report of unused steps that were not found anywhere in the audit
     def report_unused_steps
       # Remove any unused_steps that were in common modules and used
       # in another feature
       used_steps.each { |location| unused_steps.delete location }
       unused_steps.each do |location, name|
-        puts "\n" + "Unused step: #{location} ".colorize(:yellow) + 
-          "'#{name}'".colorize(:light_yellow)
+        puts "\n" + "Unused step: #{location} ".colorize(:yellow) +
+             "'#{name}'".colorize(:light_yellow)
       end
     end
 
+    # Print a report of the missing step objects provided
+    def report_missing_steps(steps)
+      puts "\nMissing steps:".colorize(:light_cyan)
+      steps.each do |step|
+        puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ')
+          .colorize(:cyan)
+      end
+    end
   end
-
 end

--- a/lib/spinach/auditor.rb
+++ b/lib/spinach/auditor.rb
@@ -7,21 +7,21 @@ module Spinach
   # when auditing.
   #
   class Auditor < Runner
-    
+
     attr_accessor :unused_steps, :used_steps
-    
+
     def initialize(filenames)
       super(filenames)
       @unused_steps = {}
       @used_steps = Set.new
-    end    
-    
+    end
+
     # audits features
     # @files [Array]
     #   filenames to audit
     def run
       require_dependencies
-      
+
       # Find any missing steps in each file, and keep track of unused steps
       clean = true
       filenames.each do |file|
@@ -29,75 +29,85 @@ module Spinach
         clean &&= result # set to false if any result is false
       end
 
-      # At the end, report any unused steps      
+      # At the end, report any unused steps
       report_unused_steps
-      
+
       # If the audit was clean, make sure the user knows
       if clean
         puts "\nAudit clean - no missing steps.".colorize(:light_green)
       end
-      
+
       true
     end
-    
+
     private
-    
+
     def audit_file(file)
       puts "\nAuditing: ".colorize(:magenta) + file.colorize(:light_magenta)
-      
+
       # Find the feature definition and its associated step defs class
       feature = Parser.open_file(file).parse
       step_defs_class = Spinach.find_step_definitions(feature.name)
       if !step_defs_class
-        puts "Step file missing: please run --generate first!".colorize(:light_red)
+        puts "Step file missing: please run --generate first!".
+          colorize(:light_red)
         return
       end
       step_defs = step_defs_class.new        
-      unused_step_names = step_defs_class.ancestors.map {|a| a.respond_to?(:steps) ? a.steps : []  }.flatten
+      unused_step_names = step_defs_class.ancestors.
+        map { |a| a.respond_to?(:steps) ? a.steps : []  }.flatten
       missing_steps = []
-                      
+
       feature.scenarios.each do |scenario|
         scenario.steps.each do |step|
           method_name = Spinach::Support.underscore step.name
           if step_defs.respond_to?(method_name)
-            # Remember the location so we can subtract from unused_steps at the end
+            # Remember the location so we can subtract from unused_steps 
+            # at the end
             location = step_defs.step_location_for(step.name).join(':')
             used_steps << location
           else
-            # OK - we can't find a step definition for this step - add it to the missing steps
-            # unless there is already a missing step of the same name
-            missing_steps << step unless missing_steps.map(&:name).include?(step.name)
+            # OK - we can't find a step definition for this step - add it to
+            # the missing steps unless there is already a missing step of the 
+            # same name
+            unless missing_steps.map(&:name).include?(step.name)
+              missing_steps << step
+            end
           end
           # Having audited the step, remove it from the list of unused steps
           unused_step_names.delete step.name
         end
       end
-      
+
       # If there are any steps left at the end, let's mark them as unused
       unused_step_names.each do |name|
         location = step_defs.step_location_for(name).join(':')
         unused_steps[location] = name
       end
-      
+
       # And then generate a report of missing steps
-      if missing_steps.length > 0
+      if missing_steps.empty?
+        return true
+      else
         puts "\nMissing steps:".colorize(:light_cyan)
-        missing_steps.each do |step|        
-          puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').colorize(:cyan)
+        missing_steps.each do |step|
+          puts Generators::StepGenerator.new(step).generate.gsub(/^/, '  ').
+            colorize(:cyan)
         end
         return false
       end
-      return true
     end
-    
+
     def report_unused_steps
-      # Remove any unused_steps that were in common modules and used in another feature
-      used_steps.each {|location| unused_steps.delete location}
+      # Remove any unused_steps that were in common modules and used
+      # in another feature
+      used_steps.each { |location| unused_steps.delete location }
       unused_steps.each do |location, name|
-        puts "\n" + "Unused step: #{location} ".colorize(:yellow) + "'#{name}'".colorize(:light_yellow)
+        puts "\n" + "Unused step: #{location} ".colorize(:yellow) + 
+          "'#{name}'".colorize(:light_yellow)
       end
     end
-    
+
   end
-  
+
 end

--- a/lib/spinach/cli.rb
+++ b/lib/spinach/cli.rb
@@ -134,9 +134,10 @@ module Spinach
                        'Terminate the suite run on the first failure') do |class_name|
             config[:fail_fast] = true
           end
-          
+
           opts.on('-a', '--audit',
-                  'Audit steps instead of running them, outputting missing and obsolete steps') do
+                  'Audit steps instead of running them, outputting missing '+
+                  'and obsolete steps') do
             config[:audit] = true
           end
         end.parse!(@args)

--- a/lib/spinach/cli.rb
+++ b/lib/spinach/cli.rb
@@ -136,8 +136,8 @@ module Spinach
           end
 
           opts.on('-a', '--audit',
-                  'Audit steps instead of running them, outputting missing '+
-                  'and obsolete steps') do
+                  "Audit steps instead of running them, outputting missing \
+and obsolete steps") do
             config[:audit] = true
           end
         end.parse!(@args)

--- a/lib/spinach/cli.rb
+++ b/lib/spinach/cli.rb
@@ -24,6 +24,8 @@ module Spinach
 
       if Spinach.config.generate
         Spinach::Generators.run(feature_files)
+      elsif Spinach.config.audit
+        Spinach::Auditor.new(feature_files).run
       else
         Spinach::Runner.new(feature_files).run
       end
@@ -131,6 +133,11 @@ module Spinach
           opts.on_tail('--fail-fast',
                        'Terminate the suite run on the first failure') do |class_name|
             config[:fail_fast] = true
+          end
+          
+          opts.on('-a', '--audit',
+                  'Audit steps instead of running them, outputting missing and obsolete steps') do
+            config[:audit] = true
           end
         end.parse!(@args)
 

--- a/lib/spinach/config.rb
+++ b/lib/spinach/config.rb
@@ -33,7 +33,8 @@ module Spinach
                 :save_and_open_page_on_failure,
                 :reporter_class,
                 :reporter_options,
-                :fail_fast
+                :fail_fast,
+                :audit
 
 
     # The "features path" holds the place where your features will be
@@ -141,6 +142,16 @@ module Spinach
     # @api public
     def fail_fast
       @fail_fast
+    end
+    
+    # "audit" enables step auditing mode
+    #
+    # @return [true/false]
+    #    The audit flag.
+    #
+    # @api public
+    def audit
+      @audit || false
     end
 
     # It allows you to set a config file to parse for all the other options to be set

--- a/lib/spinach/config.rb
+++ b/lib/spinach/config.rb
@@ -143,7 +143,7 @@ module Spinach
     def fail_fast
       @fail_fast
     end
-    
+
     # "audit" enables step auditing mode
     #
     # @return [true/false]

--- a/lib/spinach/dsl.rb
+++ b/lib/spinach/dsl.rb
@@ -142,7 +142,7 @@ module Spinach
       def feature(name)
         @feature_name = name
       end
-      
+
       # Get the list of step names in this class
       def steps
         @steps ||= []

--- a/lib/spinach/dsl.rb
+++ b/lib/spinach/dsl.rb
@@ -56,6 +56,7 @@ module Spinach
                       end
 
         define_method(Spinach::Support.underscore(step), &method_body)
+        steps << step
       end
 
       alias_method :Given, :step
@@ -140,6 +141,11 @@ module Spinach
       # @api public
       def feature(name)
         @feature_name = name
+      end
+      
+      # Get the list of step names in this class
+      def steps
+        @steps ||= []
       end
 
       private

--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -17,11 +17,10 @@ module Spinach
     def lines=(value)
       @lines = value.map(&:to_i) if value
     end
-    
+
     # Run the provided code for every step
     def each_step
       scenarios.each { |scenario| scenario.steps.each { |step| yield step } }
     end
-    
   end
 end

--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -17,5 +17,11 @@ module Spinach
     def lines=(value)
       @lines = value.map(&:to_i) if value
     end
+    
+    # Run the provided code for every step
+    def each_step
+      scenarios.each { |scenario| scenario.steps.each { |step| yield step } }
+    end
+    
   end
 end


### PR DESCRIPTION
`spinach --generate` is awesome if you get your feature files right first time, but I often find that over time features change and I have to add to or edit old feature files.

This tool helps with that. Running `spinach --audit` will do an audit of all the feature files and their shared modules.

If steps are missing, it will generate all the pending step definitions that need adding somewhere and output them to stdout.

If steps are unused, it will print out the filename and line number of the unused step so it can be removed. [**Note**: In order to do this, a slight change has been made to Spinach::DSL to have it keep track of steps as they're defined. I hope this is OK/useful!]

(The audit can also be run on individual feature files, but of course it may detect shared steps as being unused when they are in fact being used by other features! It doesn't do this when run over the whole directory.)

I have tried to keep to the coding style as much as possible and I've added a lot of scenarios to defend all the possible quirks I could think of.

Please let me know if you'd like any changes making and I hope you find this useful!