### PR TITLE
Support for RSpec mocks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -310,6 +310,14 @@ class Spinach::Features::SessionTimeout < Spinach::FeatureSteps
 end
 ```
 
+## RSpec mocks
+
+If you need access to the [rspec-mocks](https://github.com/rspec/rspec-mocks) methods in your steps, add this line to your `env.rb`:
+
+```ruby
+require 'spinach/rspec/mocks'
+```
+
 ## Reporters
 
 Spinach supports two kinds of reporters by default: `stdout` and `progress`.

--- a/lib/spinach/rspec/mocks.rb
+++ b/lib/spinach/rspec/mocks.rb
@@ -1,0 +1,18 @@
+# Inspired by cucumber/rspec/mocks
+require 'rspec/mocks'
+
+class Spinach::FeatureSteps
+  include RSpec::Mocks::ExampleMethods
+end
+
+Spinach.hooks.before_scenario do
+  RSpec::Mocks.setup
+end
+
+Spinach.hooks.after_scenario do
+  begin
+    RSpec::Mocks.verify
+  ensure
+    RSpec::Mocks.teardown
+  end
+end


### PR DESCRIPTION
This little change adds support for RSpec mocks in steps, in exactly the same way as the `cucumber/rspec/mocks` file in Cucumber.