### PR TITLE
Integration tests for scenario filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+gem 'pry-byebug', platforms: [:ruby]
 
 group :docs do
   gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
-gem 'pry-byebug', platforms: [:ruby]
 
 group :docs do
   gem 'yard'

--- a/features/running_specific_scenarios.feature
+++ b/features/running_specific_scenarios.feature
@@ -6,4 +6,14 @@ Feature: Running Specific Scenarios
   Scenario: Specifying line numbers
     Given I have a feature with 2 passing scenarios
     When I specify that only the second should be run
-    Then Only the second should be run
+    Then Only one of the scenarios should run
+
+  Scenario: Specifying tags to run
+    Given I have a feature with 2 passing scenarios with different tags
+    When I specify one of the tags to run
+    Then Only one of the scenarios should run
+
+  Scenario: Specifying tags to exclude
+    Given I have a feature with 2 passing scenarios with different tags
+    When I specify one of the tags to exclude from the run
+    Then Only one of the scenarios should run

--- a/features/running_specific_scenarios.feature
+++ b/features/running_specific_scenarios.feature
@@ -1,0 +1,9 @@
+Feature: Running Specific Scenarios
+  In order to test only specific scenarios
+  As a developer
+  I want spinach to run only the scenarios I specify
+
+  Scenario: Specifying line numbers
+    Given I have a feature with 2 passing scenarios
+    When I specify that only the second should be run
+    Then Only the second should be run

--- a/features/running_specific_scenarios.feature
+++ b/features/running_specific_scenarios.feature
@@ -4,16 +4,21 @@ Feature: Running Specific Scenarios
   I want spinach to run only the scenarios I specify
 
   Scenario: Specifying line numbers
-    Given I have a feature with 2 passing scenarios
+    Given I have a feature with 2 scenarios
     When I specify that only the second should be run
-    Then Only one of the scenarios should run
+    Then One will succeed and none will fail
 
-  Scenario: Specifying tags to run
-    Given I have a feature with 2 passing scenarios with different tags
-    When I specify one of the tags to run
-    Then Only one of the scenarios should run
+  Scenario: Including tags
+    Given I have a tagged feature with 2 scenarios
+    When I include the tag of the failing scenario
+    Then None will succeed and one will fail
 
-  Scenario: Specifying tags to exclude
-    Given I have a feature with 2 passing scenarios with different tags
-    When I specify one of the tags to exclude from the run
-    Then Only one of the scenarios should run
+  Scenario: Excluding tags
+    Given I have a tagged feature with 2 scenarios
+    When I exclude the tag of the passing scenario
+    Then None will succeed and one will fail
+
+  Scenario: Combining tags
+    Given I have a tagged feature with 2 scenarios
+    When I include the tag of the feature and exclude the tag of the failing scenario
+    Then One will succeed and none will fail

--- a/features/steps/running_specific_scenarios.rb
+++ b/features/steps/running_specific_scenarios.rb
@@ -1,11 +1,11 @@
 class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
   include Integration::SpinachRunner
 
-  step 'I have a feature with 2 passing scenarios' do
+  Given 'I have a feature with 2 passing scenarios' do
     @feature = Integration::FeatureGenerator.success_feature_with_two_scenarios
   end
 
-  step 'I specify that only the second should be run' do
+  When 'I specify that only the second should be run' do
     feature_file = Pathname.new(Filesystem.dirs.first)/@feature
     step_lines   = feature_file.each_line.with_index.select do |line, index|
       line.match(/^\s*Then/)
@@ -16,7 +16,19 @@ class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
     run_feature("#{@feature}:#{line_number}")
   end
 
-  step 'Only the second should be run' do
+  Given 'I have a feature with 2 passing scenarios with different tags' do
+    @feature = Integration::FeatureGenerator.success_feature_with_two_scenarios_with_different_tags
+  end
+
+  When 'I specify one of the tags to run' do
+    run_feature(@feature, {append: "-t @a"})
+  end
+
+  When 'I specify one of the tags to exclude from the run' do
+    run_feature(@feature, {append: "-t ~@b"})
+  end
+
+  Then 'Only one of the scenarios should run' do
     @stdout.must_match("(1) Successful")
     @stdout.must_match("(0) Failed")
     @stdout.must_match("(0) Pending")

--- a/features/steps/running_specific_scenarios.rb
+++ b/features/steps/running_specific_scenarios.rb
@@ -1,0 +1,24 @@
+class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
+  include Integration::SpinachRunner
+
+  step 'I have a feature with 2 passing scenarios' do
+    @feature = Integration::FeatureGenerator.success_feature_with_two_scenarios
+  end
+
+  step 'I specify that only the second should be run' do
+    feature_file = Pathname.new(Filesystem.dirs.first)/@feature
+    step_lines   = feature_file.each_line.with_index.select do |line, index|
+      line.match(/^\s*Then/)
+    end
+
+    line_number = step_lines[1].last
+
+    run_feature("#{@feature}:#{line_number}")
+  end
+
+  step 'Only the second should be run' do
+    @stdout.must_match("(1) Successful")
+    @stdout.must_match("(0) Failed")
+    @stdout.must_match("(0) Pending")
+  end
+end

--- a/features/steps/running_specific_scenarios.rb
+++ b/features/steps/running_specific_scenarios.rb
@@ -6,7 +6,7 @@ class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
   end
 
   When 'I specify that only the second should be run' do
-    feature_file = Pathname.new(Filesystem.dirs.first)/@feature
+    feature_file = Pathname.new(Filesystem.dirs.first).join(@feature)
     step_lines   = feature_file.each_line.with_index.select do |line, index|
       line.match(/^\s*Then/)
     end

--- a/features/steps/running_specific_scenarios.rb
+++ b/features/steps/running_specific_scenarios.rb
@@ -1,8 +1,8 @@
 class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
   include Integration::SpinachRunner
 
-  Given 'I have a feature with 2 passing scenarios' do
-    @feature = Integration::FeatureGenerator.success_feature_with_two_scenarios
+  Given 'I have a feature with 2 scenarios' do
+    @feature = Integration::FeatureGenerator.failure_feature_with_two_scenarios
   end
 
   When 'I specify that only the second should be run' do
@@ -16,21 +16,31 @@ class Spinach::Features::RunningSpecificScenarios < Spinach::FeatureSteps
     run_feature("#{@feature}:#{line_number}")
   end
 
-  Given 'I have a feature with 2 passing scenarios with different tags' do
-    @feature = Integration::FeatureGenerator.success_feature_with_two_scenarios_with_different_tags
-  end
-
-  When 'I specify one of the tags to run' do
-    run_feature(@feature, {append: "-t @a"})
-  end
-
-  When 'I specify one of the tags to exclude from the run' do
-    run_feature(@feature, {append: "-t ~@b"})
-  end
-
-  Then 'Only one of the scenarios should run' do
+  Then 'One will succeed and none will fail' do
     @stdout.must_match("(1) Successful")
     @stdout.must_match("(0) Failed")
+    @stdout.must_match("(0) Pending")    
+  end
+
+  Given 'I have a tagged feature with 2 scenarios' do
+    @feature = Integration::FeatureGenerator.tagged_failure_feature_with_two_scenarios
+  end
+
+  When 'I include the tag of the failing scenario' do
+    run_feature(@feature, {append: "-t @failing"})
+  end
+
+  Then 'None will succeed and one will fail' do
+    @stdout.must_match("(0) Successful")
+    @stdout.must_match("(1) Failed")
     @stdout.must_match("(0) Pending")
+  end
+
+  When 'I exclude the tag of the passing scenario' do
+    run_feature(@feature, {append: "-t ~@passing"})
+  end
+
+  When 'I include the tag of the feature and exclude the tag of the failing scenario' do
+    run_feature(@feature, {append: "-t @feature,~@failing"})
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require_relative 'filesystem'
-require 'pry'
 require 'simplecov'
 
 if ENV['CI'] && !defined?(Rubinius)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require_relative 'filesystem'
-
+require 'pry'
 require 'simplecov'
 
 if ENV['CI'] && !defined?(Rubinius)

--- a/features/support/feature_generator.rb
+++ b/features/support/feature_generator.rb
@@ -10,10 +10,26 @@ module Integration
       #
       # @api private
       def success_feature
-        feature= success_scenario_title + success_scenario
-        steps = success_step_class_str + success_step + "\nend"
+        feature = success_scenario_title + success_scenario
+        steps   = success_step_class_str + success_step + "\nend"
         write_feature 'features/success_feature.feature', feature,
           'features/steps/success_feature.rb', steps
+      end
+
+      # Generate a feature that has 2 scenarios. Both should pass.
+      #
+      # @return feature_filename
+      #   The feature file name
+      #
+      # @api private
+      def success_feature_with_two_scenarios
+        feature = success_scenario_title + success_scenario + "\n\n" + success_scenario
+        steps   = success_step_class_str + success_step + "\nend"
+
+        write_feature(
+          'features/success_feature.feature', feature,
+          'features/steps/success_feature.rb', steps
+        )
       end
 
       # Generate a feature with 1 scenario that has a pending step in between

--- a/features/support/feature_generator.rb
+++ b/features/support/feature_generator.rb
@@ -16,42 +16,6 @@ module Integration
           'features/steps/success_feature.rb', steps
       end
 
-      # Generate a feature that has 2 scenarios. Both should pass.
-      #
-      # @return feature_filename
-      #   The feature file name
-      #
-      # @api private
-      def success_feature_with_two_scenarios
-        feature = success_scenario_title + success_scenario + "\n\n" + success_scenario
-        steps   = success_step_class_str + success_step + "\nend"
-
-        write_feature(
-          'features/success_feature.feature', feature,
-          'features/steps/success_feature.rb', steps
-        )
-      end
-
-      # Generate a feature that has 2 differently tagged scenarios.
-      # Both should pass.
-      #
-      # @return feature_filename
-      #   The feature file name
-      #
-      # @api private
-      def success_feature_with_two_scenarios_with_different_tags
-        feature = success_scenario_title +
-          "    @a\n" + success_scenario +
-          "\n\n" +
-          "    @b\n" + success_scenario
-        steps = success_step_class_str + success_step + "\nend"
-
-        write_feature(
-          'features/success_feature.feature', feature,
-          'features/steps/success_feature.rb', steps
-        )
-      end
-
       # Generate a feature with 1 scenario that has a pending step in between
       #
       # @return feature_filename
@@ -73,10 +37,35 @@ module Integration
       #
       # @api private
       def failure_feature_with_two_scenarios
-        feature = failure_feature_title + failure_sceario + success_scenario
+        feature = failure_feature_title + failure_scenario + success_scenario
         steps = failure_step + success_step + "\nend"
         write_feature failure_filename, feature,
           failure_step_filename, steps
+      end
+
+      # Generate a tagged feature that has 2 tagged scenarios.
+      # 1 should pass, and 1 should fail.
+      #
+      # @return feature_filename
+      #   The feature file name
+      #
+      # @api private
+      def tagged_failure_feature_with_two_scenarios
+        feature = "@feature\n" +
+          failure_feature_title +
+          "  @failing" +
+          failure_scenario + "\n" +
+          "  @passing\n" +
+          "  " + success_scenario
+
+        steps = failure_step +
+          success_step + "\n" +
+          "end"
+
+        write_feature(
+          failure_filename, feature,
+          failure_step_filename, steps
+        )
       end
 
       # Generate a feature with 1 scenario that should fail
@@ -86,7 +75,7 @@ module Integration
       #
       # @api private
       def failure_feature
-        feature = failure_feature_title + failure_sceario
+        feature = failure_feature_title + failure_scenario
         write_feature failure_filename, feature,
           failure_step_filename, failure_step + "\nend"
       end
@@ -177,11 +166,10 @@ module Integration
         "Feature: A failure feature\n\n"
       end
 
-      def failure_sceario
-        """
+      def failure_scenario
+        "
   Scenario: This is scenario will fail
-    Then I fail
-        """
+    Then I fail\n"
       end
     end
   end

--- a/features/support/feature_generator.rb
+++ b/features/support/feature_generator.rb
@@ -32,6 +32,26 @@ module Integration
         )
       end
 
+      # Generate a feature that has 2 differently tagged scenarios.
+      # Both should pass.
+      #
+      # @return feature_filename
+      #   The feature file name
+      #
+      # @api private
+      def success_feature_with_two_scenarios_with_different_tags
+        feature = success_scenario_title +
+          "    @a\n" + success_scenario +
+          "\n\n" +
+          "    @b\n" + success_scenario
+        steps = success_step_class_str + success_step + "\nend"
+
+        write_feature(
+          'features/success_feature.feature', feature,
+          'features/steps/success_feature.rb', steps
+        )
+      end
+
       # Generate a feature with 1 scenario that has a pending step in between
       #
       # @return feature_filename

--- a/spinach.gemspec
+++ b/spinach.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha', '~> 1.0'
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'capybara'
-  gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'minitest', '< 5.0'

--- a/spinach.gemspec
+++ b/spinach.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha', '~> 1.0'
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'capybara'
-  gem.add_development_dependency 'pry-byebug'
+  gem.add_development_dependency 'pry'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'minitest', '< 5.0'


### PR DESCRIPTION
This is the first step of the refactor discussed in #196.

Right now tag & line number filtering takes place while iterating through the features and scenarios, which isn't compatible with randomizing them before invoking the feature & scenario runners. So the first step of that refactor is adding integration tests that test than filtering by line numbers & tags works.

Step 2 is (with these tests in place) extracting the filtering behavior to before feature & scenario runners are invoked.

Step 3 is then applying that randomization to the feature & scenario arrays (if indicated by configuration) before they are passed to feature & scenario runners.