### PR TITLE
Get FeatureRunner & ScenarioRunner ready for randomization

### DIFF
--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -1,13 +1,15 @@
 module Spinach
   class Feature
-    attr_accessor :filename, :lines
+    attr_accessor :filename
     attr_accessor :name, :scenarios, :tags
     attr_accessor :background
     attr_accessor :description
+    attr_reader   :lines
 
     def initialize
       @scenarios = []
-      @tags = []
+      @tags      = []
+      @lines     = []
     end
 
     def background_steps
@@ -16,6 +18,14 @@ module Spinach
 
     def lines=(value)
       @lines = value.map(&:to_i) if value
+    end
+
+    def only_run_scenarios_on_lines(lines)
+      self.lines = lines.map(&:to_i)
+    end
+
+    def run_every_scenario?
+      lines.empty?
     end
 
     # Run the provided code for every step

--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -16,8 +16,8 @@ module Spinach
       @background.nil? ? [] : @background.steps
     end
 
-    def lines_to_run=(value)
-      @lines_to_run = value.map(&:to_i) if value && value.any?
+    def lines_to_run=(lines)
+      @lines_to_run = lines.map(&:to_i) if lines && lines.any?
     end
 
     def run_every_scenario?

--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -17,7 +17,7 @@ module Spinach
     end
 
     def lines=(value)
-      @lines = value.map(&:to_i) if value
+      @lines = value.map(&:to_i) if value && value.any?
     end
 
     def only_run_scenarios_on_lines(lines)

--- a/lib/spinach/feature.rb
+++ b/lib/spinach/feature.rb
@@ -4,28 +4,24 @@ module Spinach
     attr_accessor :name, :scenarios, :tags
     attr_accessor :background
     attr_accessor :description
-    attr_reader   :lines
+    attr_reader   :lines_to_run
 
     def initialize
-      @scenarios = []
-      @tags      = []
-      @lines     = []
+      @scenarios    = []
+      @tags         = []
+      @lines_to_run = []
     end
 
     def background_steps
       @background.nil? ? [] : @background.steps
     end
 
-    def lines=(value)
-      @lines = value.map(&:to_i) if value && value.any?
-    end
-
-    def only_run_scenarios_on_lines(lines)
-      self.lines = lines.map(&:to_i)
+    def lines_to_run=(value)
+      @lines_to_run = value.map(&:to_i) if value && value.any?
     end
 
     def run_every_scenario?
-      lines.empty?
+      lines_to_run.empty?
     end
 
     # Run the provided code for every step

--- a/lib/spinach/parser/visitor.rb
+++ b/lib/spinach/parser/visitor.rb
@@ -73,9 +73,12 @@ module Spinach
       #
       # @api public
       def visit_Scenario(node)
-        scenario      = Scenario.new(@feature)
-        scenario.name = node.name
-        scenario.line = node.line
+        scenario       = Scenario.new(@feature)
+        scenario.name  = node.name
+        scenario.lines = [
+          node.line,
+          *node.steps.map(&:line)
+        ].uniq.sort
 
         @current_tag_set = scenario
         node.tags.each { |tag| tag.accept(self) }

--- a/lib/spinach/parser/visitor.rb
+++ b/lib/spinach/parser/visitor.rb
@@ -5,7 +5,7 @@ module Spinach
     #
     # @example
     #
-    #   ast     = GherkinRuby.parse(File.read('some.feature')
+    #   ast     = GherkinRuby.parse(File.read('some.feature'))
     #   visitor = Spinach::Parser::Visitor.new
     #   feature = visitor.visit(ast)
     #
@@ -25,7 +25,8 @@ module Spinach
       #
       # @api public
       def visit(ast)
-        ast.accept self
+        ast.accept(self)
+
         @feature
       end
 
@@ -36,12 +37,13 @@ module Spinach
       #
       # @api public
       def visit_Feature(node)
-        @feature.name = node.name
+        @feature.name        = node.name
         @feature.description = node.description
+
         node.background.accept(self) if node.background
 
         @current_tag_set = @feature
-        node.tags.each  { |tag|  tag.accept(self)  }
+        node.tags.each { |tag| tag.accept(self) }
         @current_tag_set = nil
 
         node.scenarios.each { |scenario| scenario.accept(self) }
@@ -54,7 +56,7 @@ module Spinach
       #
       # @api public
       def visit_Background(node)
-        background = Background.new(@feature)
+        background      = Background.new(@feature)
         background.line = node.line
 
         @current_step_set = background
@@ -76,7 +78,7 @@ module Spinach
         scenario.line = node.line
 
         @current_tag_set = scenario
-        node.tags.each  { |tag|  tag.accept(self)  }
+        node.tags.each { |tag| tag.accept(self) }
         @current_tag_set = nil
 
         @current_step_set = scenario
@@ -103,7 +105,7 @@ module Spinach
       #
       # @api public
       def visit_Step(node)
-        step = Step.new(@current_scenario)
+        step         = Step.new(@current_step_set)
         step.name    = node.name
         step.line    = node.line
         step.keyword = node.keyword

--- a/lib/spinach/runner.rb
+++ b/lib/spinach/runner.rb
@@ -59,7 +59,7 @@ module Spinach
       features = filenames.map do |filename|
         file, *lines = filename.split(":") # little more complex than just a "filename"
 
-        # FIXME these two lines should be Feature.from_file(filename, lines)
+        # FIXME Feature should be instantiated directly, not through an unrelated class method
         feature          = Parser.open_file(file).parse
         feature.filename = file
 

--- a/lib/spinach/runner.rb
+++ b/lib/spinach/runner.rb
@@ -63,9 +63,7 @@ module Spinach
         feature          = Parser.open_file(file).parse
         feature.filename = file
 
-        if lines.any?
-          feature.only_run_scenarios_on_lines(lines)
-        end
+        feature.lines_to_run = lines if lines.any?
 
         feature
       end

--- a/lib/spinach/runner.rb
+++ b/lib/spinach/runner.rb
@@ -37,15 +37,6 @@ module Spinach
         Spinach.config.support_path
     end
 
-    # The feature files to run
-    attr_reader :filenames
-
-    # The default path where the steps are located
-    attr_reader :step_definitions_path
-
-    # The default path where the support files are located
-    attr_reader :support_path
-
     # Inits the reporter with a default one.
     #
     # @api public

--- a/lib/spinach/runner/feature_runner.rb
+++ b/lib/spinach/runner/feature_runner.rb
@@ -85,7 +85,7 @@ module Spinach
           on_a_line_that_will_be_run = if feature.run_every_scenario?
                                          true
                                        else
-                                         (scenario.lines & feature.lines).any?
+                                         (scenario.lines & feature.lines_to_run).any?
                                        end
 
           has_a_tag_that_will_be_run && on_a_line_that_will_be_run

--- a/lib/spinach/runner/feature_runner.rb
+++ b/lib/spinach/runner/feature_runner.rb
@@ -20,7 +20,7 @@ module Spinach
       #
       # @api public
       def feature_name
-        @feature.name
+        feature.name
       end
 
       # @return [Array<GherkinRuby::AST::Scenario>]
@@ -28,7 +28,7 @@ module Spinach
       #
       # @api public
       def scenarios
-        @feature.scenarios
+        feature.scenarios
       end
 
       # Runs this feature.
@@ -38,21 +38,21 @@ module Spinach
       #
       # @api public
       def run
-        Spinach.hooks.run_before_feature @feature
+        Spinach.hooks.run_before_feature feature
         if Spinach.find_step_definitions(feature_name)
           run_scenarios!
         else
           undefined_steps!
         end
-        Spinach.hooks.run_after_feature @feature
+        Spinach.hooks.run_after_feature feature
         !@failed
       end
 
       private
 
       def feature_tags
-        if @feature.respond_to?(:tags)
-          @feature.tags
+        if feature.respond_to?(:tags)
+          feature.tags
         else
           []
         end

--- a/lib/spinach/runner/feature_runner.rb
+++ b/lib/spinach/runner/feature_runner.rb
@@ -81,7 +81,7 @@ module Spinach
 
       def scenarios_to_run
         feature.scenarios.select do |scenario|
-          has_a_tag_that_will_be_run = TagsMatcher.match(feature.tags + scenario.tags)
+          has_a_tag_that_will_be_run = TagsMatcher.match(feature_tags + scenario.tags)
           on_a_line_that_will_be_run = if feature.run_every_scenario?
                                          true
                                        else

--- a/lib/spinach/runner/feature_runner.rb
+++ b/lib/spinach/runner/feature_runner.rb
@@ -38,13 +38,16 @@ module Spinach
       #
       # @api public
       def run
-        Spinach.hooks.run_before_feature feature
+        Spinach.hooks.run_before_feature(feature)
+
         if Spinach.find_step_definitions(feature_name)
           run_scenarios!
         else
           undefined_steps!
         end
-        Spinach.hooks.run_after_feature feature
+
+        Spinach.hooks.run_after_feature(feature)
+
         !@failed
       end
 

--- a/lib/spinach/runner/feature_runner.rb
+++ b/lib/spinach/runner/feature_runner.rb
@@ -48,6 +48,9 @@ module Spinach
 
         Spinach.hooks.run_after_feature(feature)
 
+        # FIXME The feature & scenario runners should have the same structure.
+        #       They should either both return inverted failure or both return
+        #       raw success.
         !@failed
       end
 

--- a/lib/spinach/scenario.rb
+++ b/lib/spinach/scenario.rb
@@ -1,12 +1,13 @@
 module Spinach
   class Scenario
-    attr_accessor :line
+    attr_accessor :lines
     attr_accessor :name, :steps, :tags, :feature
 
     def initialize(feature)
       @feature = feature
       @steps   = []
       @tags    = []
+      @lines   = []
     end
   end
 end

--- a/test/spinach/feature_test.rb
+++ b/test/spinach/feature_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 module Spinach
   describe Feature do
-    describe "#only_run_scenarios_on_lines" do
+    describe "#lines_to_run=" do
       subject { Feature.new }
 
-      before { subject.only_run_scenarios_on_lines([4, 12]) }
+      before { subject.lines_to_run = [4, 12] }
 
-      it 'writes to @lines' do
-        subject.lines.must_equal [4, 12]
+      it 'writes lines_to_run' do
+        subject.lines_to_run.must_equal [4, 12]
       end
     end
 
@@ -22,7 +22,7 @@ module Spinach
       end
 
       describe 'when line constraints have been specified' do
-        before { subject.only_run_scenarios_on_lines([4, 12]) }
+        before { subject.lines_to_run = [4, 12] }
 
         it 'is false' do
           subject.run_every_scenario?.must_equal false

--- a/test/spinach/feature_test.rb
+++ b/test/spinach/feature_test.rb
@@ -2,5 +2,32 @@ require 'test_helper'
 
 module Spinach
   describe Feature do
+    describe "#only_run_scenarios_on_lines" do
+      subject { Feature.new }
+
+      before { subject.only_run_scenarios_on_lines([4, 12]) }
+
+      it 'writes to @lines' do
+        subject.lines.must_equal [4, 12]
+      end
+    end
+
+    describe '#run_every_scenario?' do
+      subject { Feature.new }
+
+      describe 'when no line constraints have been specified' do
+        it 'is true' do
+          subject.run_every_scenario?.must_equal true
+        end
+      end
+
+      describe 'when line constraints have been specified' do
+        before { subject.only_run_scenarios_on_lines([4, 12]) }
+
+        it 'is false' do
+          subject.run_every_scenario?.must_equal false
+        end
+      end
+    end
   end
 end

--- a/test/spinach/parser/visitor_test.rb
+++ b/test/spinach/parser/visitor_test.rb
@@ -63,7 +63,11 @@ module Spinach
 
       describe '#visit_Scenario' do
         before do
-          @steps = [stub_everything, stub_everything, stub_everything]
+          @steps = [
+            stub_everything(line: 4),
+            stub_everything(line: 5),
+            stub_everything(line: 6)
+          ]
           @tags  = [stub_everything, stub_everything, stub_everything]
           @node  = stub(
             tags:  @tags,
@@ -83,9 +87,9 @@ module Spinach
           visitor.feature.scenarios.first.name.must_equal 'Go shopping on Saturday morning'
         end
 
-        it 'sets the line' do
+        it 'sets the lines' do
           visitor.visit_Scenario(@node)
-          visitor.feature.scenarios.first.line.must_equal 3
+          visitor.feature.scenarios.first.lines.must_equal (3..6).to_a
         end
 
         it 'sets the tags' do

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -100,38 +100,46 @@ describe Spinach::Runner::FeatureRunner do
       end
     end
 
-    describe "when a line is given" do
+    describe "when only running specific lines" do
       before do
-        @feature = stub('feature', name: 'Feature')
-        Spinach.stubs(:find_step_definitions).returns(true)
         @scenarios = [
-          scenario         = stub(line: 4, tags: []),
-          another_scenario = stub(line: 12, tags: [])
+          stub(tags: [], lines: (4..8).to_a),
+          stub(tags: [], lines: (12..15).to_a),
         ]
-        @feature.stubs(:scenarios).returns @scenarios
+        @feature = stub('feature',
+          name:                'Feature',
+          tags:                [],
+          scenarios:           @scenarios,
+          run_every_scenario?: false,
+        )
+        Spinach.stubs(:find_step_definitions).returns(true)
       end
 
       it "runs exactly matching scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[1]).returns stub(run: true)
-        @runner = Spinach::Runner::FeatureRunner.new(@feature, "12")
+        @feature.stubs(:lines).returns([12])
+        @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs no scenario and returns false" do
         Spinach::Runner::ScenarioRunner.expects(:new).never
-        @runner = Spinach::Runner::FeatureRunner.new(@feature, "3")
+        @feature.stubs(:lines).returns([3])
+        @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs matching scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[0]).returns stub(run: true)
-        @runner = Spinach::Runner::FeatureRunner.new(@feature, "8")
+        @feature.stubs(:lines).returns([8])
+        @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs last scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[1]).returns stub(run: true)
-        @runner = Spinach::Runner::FeatureRunner.new(@feature, "15")
+        @feature.stubs(:lines).returns([15])
+        @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
     end

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -24,13 +24,15 @@ describe Spinach::Runner::FeatureRunner do
   end
 
   describe '#run' do
-    it 'runs the hooks in order' do
-      hooks = sequence('hooks')
-      Spinach.hooks.expects(:run_before_feature).with(feature).in_sequence(hooks)
-      Spinach.expects(:find_step_definitions).returns(false).in_sequence(hooks)
-      Spinach.hooks.expects(:run_after_feature).with(feature).in_sequence(hooks)
+    describe "when some steps don't exist" do
+      it 'runs the hooks in order' do
+        hooks = sequence('hooks')
+        Spinach.hooks.expects(:run_before_feature).with(feature).in_sequence(hooks)
+        Spinach.expects(:find_step_definitions).returns(false).in_sequence(hooks)
+        Spinach.hooks.expects(:run_after_feature).with(feature).in_sequence(hooks)
 
-      subject.run
+        subject.run
+      end
     end
 
     describe 'when the steps exist' do
@@ -57,13 +59,15 @@ describe Spinach::Runner::FeatureRunner do
       end
 
       describe 'and the scenarios fail' do
-        it 'runs the scenarios and returns false' do
-          @scenarios.each do |scenario|
-            runner = stub(run: false)
-            Spinach::Runner::ScenarioRunner.expects(:new).with(scenario).returns runner
-          end
+        describe "without config option fail_fast set" do
+          it 'runs the scenarios and returns false' do
+            @scenarios.each do |scenario|
+              runner = stub(run: false)
+              Spinach::Runner::ScenarioRunner.expects(:new).with(scenario).returns runner
+            end
 
-          @runner.run.must_equal false
+            @runner.run.must_equal false
+          end
         end
 
         describe "with config option fail_fast set" do

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -37,13 +37,17 @@ describe Spinach::Runner::FeatureRunner do
 
     describe 'when the steps exist' do
       before do
-        @feature = stub('feature', name: 'Feature')
-        Spinach.stubs(:find_step_definitions).returns(true)
         @scenarios = [
           scenario         = stub(tags: []),
           another_scenario = stub(tags: [])
         ]
-        @feature.stubs(:scenarios).returns @scenarios
+        @feature = stub('feature',
+          name:                "Feature",
+          tags:                [],
+          scenarios:           @scenarios,
+          run_every_scenario?: true
+        )
+        Spinach.stubs(:find_step_definitions).returns(true)
         @runner = Spinach::Runner::FeatureRunner.new(@feature)
       end
 

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -14,11 +14,6 @@ describe Spinach::Runner::FeatureRunner do
     it 'initializes the given filename' do
       subject.feature.must_equal feature
     end
-
-    it 'initalizes the given scenario line' do
-      @runner = Spinach::Runner::FeatureRunner.new(feature, '34')
-      @runner.instance_variable_get(:@line).must_equal 34
-    end
   end
 
   describe '#scenarios' do

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -35,7 +35,7 @@ describe Spinach::Runner::FeatureRunner do
       end
     end
 
-    describe 'when the steps exist' do
+    describe 'when all the steps exist' do
       before do
         @scenarios = [
           scenario         = stub(tags: []),

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -117,28 +117,28 @@ describe Spinach::Runner::FeatureRunner do
 
       it "runs exactly matching scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[1]).returns stub(run: true)
-        @feature.stubs(:lines).returns([12])
+        @feature.stubs(:lines_to_run).returns([12])
         @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs no scenario and returns false" do
         Spinach::Runner::ScenarioRunner.expects(:new).never
-        @feature.stubs(:lines).returns([3])
+        @feature.stubs(:lines_to_run).returns([3])
         @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs matching scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[0]).returns stub(run: true)
-        @feature.stubs(:lines).returns([8])
+        @feature.stubs(:lines_to_run).returns([8])
         @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end
 
       it "runs last scenario" do
         Spinach::Runner::ScenarioRunner.expects(:new).with(@scenarios[1]).returns stub(run: true)
-        @feature.stubs(:lines).returns([15])
+        @feature.stubs(:lines_to_run).returns([15])
         @runner = Spinach::Runner::FeatureRunner.new(@feature)
         @runner.run
       end

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -1,14 +1,14 @@
 require_relative '../../test_helper'
 
 describe Spinach::Runner::FeatureRunner do
-  let(:feature) { 
-    stub('feature', 
-         name: 'Feature',
-         scenarios: [],
-         background_steps: []
-        )
-  }
-  subject{ Spinach::Runner::FeatureRunner.new(feature) }
+  let(:feature) do
+    stub('feature',
+      name:             'Feature',
+      scenarios:        [],
+      background_steps: []
+    )
+  end
+  subject { Spinach::Runner::FeatureRunner.new(feature) }
 
   describe '#initialize' do
     it 'initializes the given filename' do

--- a/test/spinach/runner/feature_runner_test.rb
+++ b/test/spinach/runner/feature_runner_test.rb
@@ -140,10 +140,14 @@ describe Spinach::Runner::FeatureRunner do
 
       describe "with feature" do
         before do
-          @feature = stub('feature', name: 'Feature', tags: ["feature_tag"])
+          @scenario = stub(tags: [])
+          @feature = stub('feature',
+            name:                'Feature',
+            tags:                ["feature_tag"],
+            scenarios:           [@scenario],
+            run_every_scenario?: true,
+          )
           Spinach.stubs(:find_step_definitions).returns(true)
-          @scenario = stub(line: 4, tags: [])
-          @feature.stubs(:scenarios).returns [@scenario]
         end
 
         it "runs matching feature" do
@@ -157,10 +161,14 @@ describe Spinach::Runner::FeatureRunner do
 
       describe "with scenario" do
         before do
-          @feature = stub('feature', name: 'Feature', tags: ["feature_tag"])
+          @scenario = stub(tags: ["scenario_tag"])
+          @feature = stub('feature',
+            name:                'Feature',
+            tags:                ["feature_tag"],
+            scenarios:           [@scenario],
+            run_every_scenario?: true,
+          )
           Spinach.stubs(:find_step_definitions).returns(true)
-          @scenario = stub(line: 4, tags: ["scenario_tag"])
-          @feature.stubs(:scenarios).returns [@scenario]
         end
 
         it "runs matching scenario" do
@@ -180,7 +188,7 @@ describe Spinach::Runner::FeatureRunner do
         end
 
         it "doesn't accumulate tags from one scenario to the next" do
-          next_scenario = stub(line: 14, tags: [])
+          next_scenario = stub(tags: [])
           @feature.stubs(:scenarios).returns [@scenario, next_scenario]
 
           Spinach::TagsMatcher.expects(:match).with(["feature_tag", "scenario_tag"]).returns true

--- a/test/spinach/runner_test.rb
+++ b/test/spinach/runner_test.rb
@@ -107,7 +107,7 @@ describe Spinach::Runner do
       let(:filenames) { ["#{filename}:#{line}"] }
       let(:runner) { Spinach::Runner.new(filenames) }
 
-      it 'sets filename and line on the feature' do
+      it 'sets filename and lines_to_run on the feature' do
         @feature_runner = stub
         Spinach::Parser.stubs(:open_file).with(filename).returns parser = stub
         parser.stubs(:parse).returns feature = Spinach::Feature.new
@@ -119,7 +119,7 @@ describe Spinach::Runner do
 
         runner.run.must_equal true
         feature.filename.must_equal filename
-        feature.lines.must_equal [line]
+        feature.lines_to_run.must_equal [line]
       end
     end
 
@@ -139,11 +139,11 @@ describe Spinach::Runner do
         runner.stubs(required_files: [])
       end
 
-      it "sets filename and lines on the feature" do
+      it "sets filename and lines_to_run on the feature" do
         @feature_runner.stubs(:run).returns(true)
         runner.run.must_equal true
         @feature.filename.must_equal filename
-        @feature.lines.must_equal line.split(":").map(&:to_i)
+        @feature.lines_to_run.must_equal line.split(":").map(&:to_i)
       end
 
       it "returns false if it fails" do


### PR DESCRIPTION
In order to easily and cleanly apply seeded randomization to both `Feature`s and `Scenario`s, we have to know which `Feature`s and `Scenario`s are going to get run before we start iteration. The 2 big changes are:
* instead of iterating over the `filenames` array in `FeatureRunner#run`, we use it to determine a `features` array and iterate over that instead.
* instead of asking each `Scenario` if we should run it as we come upon it, in `ScenarioRunner#run_scenarios!`, we instead call the `scenarios_to_run` private method.
These changes provide us with a seam in each Runner where we can manipulate the order of their respective "runnables".
One small change that supports this:
* a `Scenario` now knows every line that it takes up in it's file, instead of just the one it starts on.