### PR TITLE
Support for multiple reporters, plus a new file reporter

### DIFF
--- a/features/reporting/customized_reporter.feature
+++ b/features/reporting/customized_reporter.feature
@@ -7,3 +7,9 @@ Feature: Use customized reporter
     Given I have a feature that has no error or failure
     When I run it using the new reporter
     Then I see the desired output
+
+  Scenario: Multiple reporters
+    Given I have a feature that has one failure
+    When I run it using two custom reporters
+    Then I see one reporter's output on the screen
+    And I see the other reporter's output in a file

--- a/features/steps/reporting/use_customized_reporter.rb
+++ b/features/steps/reporting/use_customized_reporter.rb
@@ -15,7 +15,7 @@ class UseCustomizedReporter < Spinach::FeatureSteps
 
     def initialize(*args)
       super(*args)
-        @out = options[:output] || $stdout
+      @out = options[:output] || $stdout
       @error = options[:error] || $stderr
       @max_step_name_length = 0
     end

--- a/features/support/filesystem.rb
+++ b/features/support/filesystem.rb
@@ -46,11 +46,14 @@ module Filesystem
   #
   # @param [String] command
   #   The command to run.
+  # @param [Hash] env
+  #   Hash of environment variables to use with command
   #
   # @api public
-  def run(command)
+  def run(command, env = nil)
     in_current_dir do
       args = command.strip.split(" ")
+      args = args.unshift(env) if env
       @stdout, @stderr, @last_exit_status = Open3.capture3(*args)
     end
 

--- a/features/support/spinach_runner.rb
+++ b/features/support/spinach_runner.rb
@@ -20,7 +20,7 @@ module Integration
       use_minitest if options[:framework] == :minitest
       use_rspec if options[:framework] == :rspec
       spinach = File.expand_path("bin/spinach")
-      run "#{ruby} #{spinach} #{feature} #{options[:append]}"
+      run "#{ruby} #{spinach} #{feature} #{options[:append]}", options[:env]
     end
 
     def ruby

--- a/lib/spinach/cli.rb
+++ b/lib/spinach/cli.rb
@@ -125,9 +125,10 @@ module Spinach
             config[:features_path] = path
           end
 
-          opts.on('-r', '--reporter CLASS_NAME',
-                  'Formatter class name') do |class_name|
-            config[:reporter_class] = reporter_class(class_name)
+          opts.on('-r', '--reporter CLASS_NAMES',
+                  'Formatter class names, separated by commas') do |class_names|
+            names = class_names.split(',').map { |c| reporter_class(c) }
+            config[:reporter_classes] = names
           end
 
           opts.on_tail('--fail-fast',

--- a/lib/spinach/config.rb
+++ b/lib/spinach/config.rb
@@ -31,7 +31,7 @@ module Spinach
                 :tags,
                 :generate,
                 :save_and_open_page_on_failure,
-                :reporter_class,
+                :reporter_classes,
                 :reporter_options,
                 :fail_fast,
                 :audit
@@ -48,18 +48,18 @@ module Spinach
       @features_path || 'features'
     end
 
-    # The "reporter class" holds the reporter class name
-    # Default to Spinach::Reporter::Stdout
+    # The "reporter classes" holds an array of reporter class name
+    # Default to ["Spinach::Reporter::Stdout"]
     #
-    # @return [reporter object]
-    #    The reporter that responds to specific messages.
+    # @return [Array<reporter object>]
+    #    The reporters that respond to specific messages.
     #
     # @api public
-    def reporter_class
-      @reporter_class || "Spinach::Reporter::Stdout"
+    def reporter_classes
+      @reporter_classes || ["Spinach::Reporter::Stdout"]
     end
 
-    # The "reporter_options" holds the options of reporter_class
+    # The "reporter_options" holds the options passed to reporter_classes
     #
     # @api public
     def reporter_options

--- a/lib/spinach/reporter.rb
+++ b/lib/spinach/reporter.rb
@@ -96,3 +96,4 @@ end
 
 require_relative 'reporter/stdout'
 require_relative 'reporter/progress'
+require_relative 'reporter/failure_file'

--- a/lib/spinach/reporter/failure_file.rb
+++ b/lib/spinach/reporter/failure_file.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+require_relative 'reporting'
+require 'pp'
+
+module Spinach
+  class Reporter
+    # The FailureFile reporter outputs failing scenarios to a temporary file, one per line.
+    #
+    class FailureFile < Reporter
+
+      # Initializes the output filename and the temporary directory.
+      #
+      def initialize(*args)
+        super(*args)
+
+        # Generate a unique filename for this test run, or use the supplied option
+        @filename = options[:failure_filename] || ENV['SPINACH_FAILURE_FILE'] || "tmp/spinach-failures_#{Time.now.strftime('%F_%H-%M-%S-%L')}.txt"
+
+        # Create the temporary directory where we will output our file, if necessary
+        Dir.mkdir('tmp', 0755) unless Dir.exist?('tmp')
+
+        # Collect an array of failing scenarios
+        @failing_scenarios = []
+      end
+
+      attr_reader :failing_scenarios, :filename
+
+      # Writes all failing scenarios to a file, unless our run was successful.
+      #
+      # @param [Boolean] success
+      #   Indicates whether the entire test run was successful
+      #
+      def after_run(success)
+        # Save our failed scenarios to a file
+        File.open(@filename, 'w') { |f| f.write @failing_scenarios.join("\n") } unless success
+      end
+
+      # Adds a failing step to the output buffer.
+      #
+      def on_failed_step(*args)
+        add_scenario(current_feature.filename, current_scenario.lines[0])
+      end
+
+      # Adds a step that has raised an error to the output buffer.
+      #
+      def on_error_step(*args)
+        add_scenario(current_feature.filename, current_scenario.lines[0])
+      end
+
+      private
+
+      # Adds a filename and line number to the output buffer, suitable for rerunning.
+      #
+      def add_scenario(filename, line)
+        @failing_scenarios << "#{filename}:#{line}"
+      end
+    end
+  end
+end

--- a/lib/spinach/runner.rb
+++ b/lib/spinach/runner.rb
@@ -40,9 +40,11 @@ module Spinach
     # Inits the reporter with a default one.
     #
     # @api public
-    def init_reporter
-      reporter = Support.constantize(Spinach.config[:reporter_class]).new(Spinach.config.reporter_options)
-      reporter.bind
+    def init_reporters
+      Spinach.config[:reporter_classes].each do |reporter_class|
+        reporter = Support.constantize(reporter_class).new(Spinach.config.reporter_options)
+        reporter.bind
+      end
     end
 
     # Runs this runner and outputs the results in a colorful manner.
@@ -54,7 +56,7 @@ module Spinach
     def run
       require_dependencies
       require_frameworks
-      init_reporter
+      init_reporters
 
       features = filenames.map do |filename|
         file, *lines = filename.split(":") # little more complex than just a "filename"

--- a/test/spinach/cli_test.rb
+++ b/test/spinach/cli_test.rb
@@ -76,7 +76,15 @@ tags:
           Spinach.stubs(:config).returns(config)
           cli = Spinach::Cli.new([opt, 'progress'])
           cli.options
-          config.reporter_class.must_equal 'Spinach::Reporter::Progress'
+          config.reporter_classes.must_equal ['Spinach::Reporter::Progress']
+        end
+
+        it 'sets multiple reporter classes' do
+          config = Spinach::Config.new
+          Spinach.stubs(:config).returns(config)
+          cli = Spinach::Cli.new([opt, 'progress,stdout'])
+          cli.options
+          config.reporter_classes.must_equal ['Spinach::Reporter::Progress', 'Spinach::Reporter::Stdout']
         end
       end
     end

--- a/test/spinach/config_test.rb
+++ b/test/spinach/config_test.rb
@@ -16,14 +16,14 @@ describe Spinach::Config do
    end
  end
 
- describe '#reporter_class' do
+ describe '#reporter_classes' do
    it 'returns a default' do
-     subject[:reporter_class].must_equal "Spinach::Reporter::Stdout"
+     subject[:reporter_classes].must_equal ["Spinach::Reporter::Stdout"]
    end
 
    it 'can be overwritten' do
-     subject[:reporter_class] = "MyOwnReporter"
-     subject[:reporter_class].must_equal "MyOwnReporter"
+     subject[:reporter_classes] = ["MyOwnReporter"]
+     subject[:reporter_classes].must_equal ["MyOwnReporter"]
    end
  end
 

--- a/test/spinach/reporter/failure_file_test.rb
+++ b/test/spinach/reporter/failure_file_test.rb
@@ -1,0 +1,84 @@
+# encoding: utf-8
+
+require_relative '../../test_helper'
+
+describe Spinach::Reporter::FailureFile do
+  let(:feature) { stub_everything(filename: 'features/test.feature') }
+  let(:scenario) { stub_everything(lines: [1,2]) }
+
+  describe '#initialize' do
+    it 'generates a distinctive output filename if none is provided' do
+      @reporter = Spinach::Reporter::FailureFile.new
+      @reporter.filename.wont_be_nil
+      @reporter.filename.must_be_kind_of String
+    end
+
+    it 'uses a provided output filename option' do
+      @reporter = Spinach::Reporter::FailureFile.new(failure_filename: 'foo')
+      @reporter.filename.must_equal 'foo'
+    end
+
+    it 'uses a provided output filename environment variable' do
+      ENV['SPINACH_FAILURE_FILE'] = 'asdf'
+      @reporter = Spinach::Reporter::FailureFile.new
+      @reporter.filename.must_equal 'asdf'
+    end
+
+    it 'initializes the array of failing scenarios' do
+      @reporter = Spinach::Reporter::FailureFile.new
+      @reporter.failing_scenarios.wont_be_nil
+      @reporter.failing_scenarios.must_be_kind_of Array
+      @reporter.failing_scenarios.must_be_empty
+    end
+
+    after do
+      ENV.delete('SPINACH_FAILURE_FILE')
+    end
+  end
+
+  describe 'hooks' do
+    before do
+      @reporter = Spinach::Reporter::FailureFile.new(failure_filename: "tmp/test-failures_#{Time.now.strftime('%F_%H-%M-%S-%L')}.txt")
+      @reporter.set_current_feature(feature)
+      @reporter.set_current_scenario(scenario)
+    end
+
+    describe '#on_failed_step' do
+      it 'collects the feature and line number for outputting later' do
+        @reporter.failing_scenarios.must_be_empty
+        @reporter.on_failed_step(anything)
+        @reporter.failing_scenarios.must_include "#{feature.filename}:#{scenario.lines[0]}"
+      end
+    end
+
+    describe '#on_error_step' do
+      it 'collects the feature and line number for outputting later' do
+        @reporter.failing_scenarios.must_be_empty
+        @reporter.on_error_step(anything)      
+        @reporter.failing_scenarios.must_include "#{feature.filename}:#{scenario.lines[0]}"
+      end
+    end
+
+    describe '#after_run' do
+      describe 'when the run has succeeded' do
+        it 'no failure file is created' do
+          @reporter.after_run(true)
+          refute File.exist?(@reporter.filename), 'Output file should not exist when run is successful'
+        end
+      end
+
+      describe 'when the run has failed' do
+        it 'failure file is created and includes expected output' do
+          @reporter.on_failed_step(anything)
+          @reporter.after_run(false)
+          assert File.exist?(@reporter.filename)
+          f = File.open(@reporter.filename)
+          f.read.must_equal "#{feature.filename}:#{scenario.lines[0]}"
+          f.close
+          File.unlink(@reporter.filename)
+        end
+      end
+    end
+  end
+
+end

--- a/test/spinach/runner_test.rb
+++ b/test/spinach/runner_test.rb
@@ -36,25 +36,25 @@ describe Spinach::Runner do
     end
   end
 
-  describe '#init_reporter' do
-    describe "when no reporter_class option is passed in" do
+  describe '#init_reporters' do
+    describe "when no reporter_classes option is passed in" do
       it 'inits the default reporter' do
         reporter = stub
         reporter.expects(:bind)
         Spinach::Reporter::Stdout.stubs(new: reporter)
-        runner.init_reporter
+        runner.init_reporters
       end
     end
 
-    describe "when reporter_class option is passed in" do
-      it "inits the reporter class" do
+    describe "when reporter_classes option is passed in" do
+      it "inits the reporter classes" do
         config = Spinach::Config.new
         Spinach.stubs(:config).returns(config)
-        config.reporter_class = "String"
+        config.reporter_classes = ["String"]
         reporter = stub
         reporter.expects(:bind)
         String.stubs(new: reporter)
-        runner.init_reporter
+        runner.init_reporters
       end
     end
 
@@ -66,7 +66,7 @@ describe Spinach::Runner do
         reporter = stub
         reporter.stubs(:bind)
         Spinach::Reporter::Stdout.expects(new: reporter).with(backtrace: true)
-        runner.init_reporter
+        runner.init_reporters
       end
     end
   end
@@ -86,8 +86,8 @@ describe Spinach::Runner do
       runner.stubs(required_files: [])
     end
 
-    it "inits reporter" do
-      runner.expects(:init_reporter)
+    it "inits reporters" do
+      runner.expects(:init_reporters)
       runner.run
     end
 


### PR DESCRIPTION
Per #199, I've attempted to add support for running Spinach with more than one reporter at a time.

```
spinach -r reporter1,reporter2
```

As it doesn't make much sense to use two reporters that both output to the screen, I've also included a new `FailureFile` reporter that, with much inspiration from [spinach-rerun-reporter](https://github.com/javierav/spinach-rerun-reporter), will output offending scenarios to a file.

It was very useful for me to develop and test the multiple reporter functionality with a working file reporter, but I completely understand if you'd rather I pull the new reporter into a separate PR or an independent repo.