### PR TITLE
upgrade jruby to get around capybara syntax issue in jruby test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ rvm:
   - 2.1.9
   - 2.2.4
   - 2.3.1
-  - jruby-9.1.2.0
+  - jruby-9.1.6.0
 
 cache: bundler
 script: "bundle exec rake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ rvm:
   - 2.1.9
   - 2.2.4
   - 2.3.1
-  - jruby-9.1.6.0
+  - jruby-9.1.9.0
 
 cache: bundler
 script: "bundle exec rake"


### PR DESCRIPTION
We routinely see an error in JRuby runs on Travis when loading the file capybara/node/actions.

The reason for this is that it contains squiggly heredocs with delimiters with quotes (<<~'JS' to be specific).
link: https://github.com/teamcapybara/capybara/blob/3.2.0/lib/capybara/node/actions.rb#L310-L331

JRuby couldn't parse squiggly heredocs with single quotes in the delimeter until 9.1.6.0. We're currently telling Travis to use 9.1.2.0.
link: https://github.com/jruby/jruby/issues/4169

Because capybara isn't a runtime dependency for spinach, making our JRuby runs on Travis use a newer version of JRuby doesn't actually affect our users. The alternative, getting capybara's maintainers to accept a PR removing the quotes from the heredoc delimeters in that file, seems like it would take much more effort, for very little benefit.

As a side note, I have no clue what the benefit of adding quotes (single or double) to a heredoc delimeter is. Those heredocs in capybara/node/actions work fine with or without quotes in the delimeter.