### PR TITLE
Ruby 3.2 fix: remove `File.exists?` usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         ruby: [2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, jruby]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: ruby/setup-ruby@master
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install --jobs 4 --retry 3
-        name: Install Ruby deps
+          bundler-cache: true
       - run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, jruby]
+        ruby: [2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, jruby]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.0.0

--- a/features/steps/automatic_feature_generation.rb
+++ b/features/steps/automatic_feature_generation.rb
@@ -20,7 +20,7 @@ Feature: Cheezburger can I has
   Then 'I a feature should exist named "features/steps/cheezburger_can_i_has.rb"' do
     in_current_dir do
       @file = 'features/steps/cheezburger_can_i_has.rb'
-      File.exists?(@file).must_equal true
+      File.exist?(@file).must_equal true
     end
   end
 

--- a/lib/spinach/cli.rb
+++ b/lib/spinach/cli.rb
@@ -56,7 +56,7 @@ module Spinach
 
       @args.each do |arg|
         if arg.match(/\.feature/)
-          if File.exists? arg.gsub(/:\d*/, '')
+          if File.exist? arg.gsub(/:\d*/, '')
             files_to_run << arg
           else
             fail! "#{arg} could not be found"

--- a/test/spinach/cli_test.rb
+++ b/test/spinach/cli_test.rb
@@ -276,14 +276,14 @@ tags:
       describe 'the feature really exists' do
         it 'runs the feature' do
           cli = Spinach::Cli.new(['features/some_feature.feature'])
-          File.stubs(:exists?).returns(true)
+          File.stubs(:exist?).returns(true)
           cli.feature_files.must_equal ['features/some_feature.feature']
         end
       end
 
       it 'it fails if the feature does not exist' do
         cli = Spinach::Cli.new(['features/some_feature.feature'])
-        File.stubs(:exists?).returns(false)
+        File.stubs(:exist?).returns(false)
         cli.expects(:fail!).with('features/some_feature.feature could not be found')
 
         cli.feature_files
@@ -293,7 +293,7 @@ tags:
     describe 'when a particular feature list is passed with line' do
       it 'returns the feature with the line number' do
         cli = Spinach::Cli.new(['features/some_feature.feature:10'])
-        File.stubs(:exists?).returns(true)
+        File.stubs(:exist?).returns(true)
 
         cli.feature_files.must_equal ['features/some_feature.feature:10']
       end
@@ -302,7 +302,7 @@ tags:
     describe "when a particular feature list is passed with multiple lines" do
       it "returns the feature with the line numbers" do
         cli = Spinach::Cli.new(['features/some_feature.feature:10:20'])
-        File.stubs(:exists?).returns(true)
+        File.stubs(:exist?).returns(true)
 
         cli.feature_files.must_equal ["features/some_feature.feature:10:20"]
       end
@@ -337,7 +337,7 @@ tags:
           Dir.expects(:glob).with('path/to/features/**/*.feature')
           .returns(['several features'])
 
-          File.stubs(:exists?).returns(true)
+          File.stubs(:exist?).returns(true)
 
           cli.feature_files.must_equal ['several features', 'some_feature.feature']
         end

--- a/test/spinach/dsl_test.rb
+++ b/test/spinach/dsl_test.rb
@@ -157,7 +157,7 @@ describe Spinach::DSL do
         end
 
         @feature.new.step_location_for('I say goodbye').first.must_include '/dsl_test.rb'
-        @feature.new.step_location_for('I say goodbye').last.must_be_kind_of Fixnum
+        @feature.new.step_location_for('I say goodbye').last.must_be_kind_of Integer
       end
     end
   end

--- a/test/spinach/generators/feature_generator_test.rb
+++ b/test/spinach/generators/feature_generator_test.rb
@@ -71,7 +71,7 @@ Feature: Cheezburger can I has
         in_current_dir do
           subject.store
           File.directory?("features/steps/").must_equal true
-          File.exists?("features/steps/cheezburger_can_i_has.rb").must_equal true
+          File.exist?("features/steps/cheezburger_can_i_has.rb").must_equal true
           File.read("features/steps/cheezburger_can_i_has.rb").strip.must_equal(
             subject.generate.strip
           )

--- a/test/spinach/reporter_test.rb
+++ b/test/spinach/reporter_test.rb
@@ -89,8 +89,8 @@ module Spinach
 
         it "binds a callback around every scenario" do
           @reporter.expects(:around_scenario_run)
-          Spinach.hooks.run_around_scenario(anything) do
-            yield
+          Spinach.hooks.run_around_scenario(anything) do |&block|
+            block.call
           end
         end
 


### PR DESCRIPTION
## ✍️ Description

Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix along with Ruby 3.1 and 3.0. 

## ✅ Fixes

Resolve use of deprecated `File.exists?` method. (Replaced with `File.exist?`.)

`File.exists?` was removed in Ruby 3.2.
