### PR TITLE
Added support for Minitest 5.

### DIFF
--- a/lib/spinach/frameworks/minitest.rb
+++ b/lib/spinach/frameworks/minitest.rb
@@ -1,13 +1,34 @@
 require 'minitest/spec'
-MiniTest::Spec.new nil if defined?(MiniTest::Spec)
-Spinach.config[:failure_exceptions] << MiniTest::Assertion
 
-class Spinach::FeatureSteps
-  include MiniTest::Assertions
-  attr_accessor :assertions
+if defined? MiniTest::Spec
+  MiniTest::Spec.new nil
+elsif defined? Minitest::Spec
+  Minitest::Spec.new nil
+end
 
-  def initialize(*args)
-    super *args
-    self.assertions = 0
+if defined? MiniTest::Assertion
+  Spinach.config[:failure_exceptions] << MiniTest::Assertion
+
+  class Spinach::FeatureSteps
+    include MiniTest::Assertions
+    attr_accessor :assertions
+  
+    def initialize(*args)
+      super *args
+      self.assertions = 0
+    end
+  end 
+elsif defined? Minitest::Assertion
+  Spinach.config[:failure_exceptions] << Minitest::Assertion
+
+  class Spinach::FeatureSteps
+    include Minitest::Assertions
+    attr_accessor :assertions
+  
+    def initialize(*args)
+      super *args
+      self.assertions = 0
+    end
   end
 end
+

--- a/spinach.gemspec
+++ b/spinach.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'gherkin-ruby', '>= 0.3.2'
   gem.add_runtime_dependency 'colorize'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'mocha', "~> 1.5.0"
+  gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'minitest', '< 5.0'
+  gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'fakefs', ">= 0.5.2"
 
   gem.required_ruby_version = Gem::Requirement.new(">= 2.4".freeze)

--- a/test/spinach/frameworks/minitest_test.rb
+++ b/test/spinach/frameworks/minitest_test.rb
@@ -6,11 +6,23 @@ describe "minitest framework" do
   end
 
   it "adds MiniTest::Assertion into the failure exceptions" do
-    Spinach.config[:failure_exceptions].must_include MiniTest::Assertion
+    if defined? MiniTest::Assertion
+      Spinach.config[:failure_exceptions].must_include MiniTest::Assertion
+    elsif defined? Minitest::Assertion
+      Spinach.config[:failure_exceptions].must_include Minitest::Assertion
+    else
+      fail
+    end
   end
 
   it "extends the FeatureSteps class with MiniTest DSL" do
-    Spinach::FeatureSteps.ancestors.must_include MiniTest::Assertions
+    if defined? MiniTest::Assertion
+      Spinach::FeatureSteps.ancestors.must_include MiniTest::Assertions
+    elsif defined? Minitest::Assertion
+      Spinach::FeatureSteps.ancestors.must_include Minitest::Assertions
+    else
+      fail
+    end
   end
 
   it "makes FeatureSteps respond to 'assertions'" do

--- a/test/support/filesystem.rb
+++ b/test/support/filesystem.rb
@@ -10,4 +10,8 @@ module Filesystem
   end
 end
 
-MiniTest::Spec.send(:include, Filesystem)
+if defined? MiniTest::Spec
+  MiniTest::Spec.send(:include, Filesystem)
+elsif defined? Minitest::Spec
+  Minitest::Spec.send(:include, Filesystem)
+end


### PR DESCRIPTION
## ✍️ Description

Adding support for Minitest 5. Looks like namespace has changed.

LMK if this looks right, or whether it makes sense to drop support for minitest 4.x altogether and I'll try to finish this. Will also need to add CI that does both minitest 4 and 5.

## ✅ Fixes

(optional)

- Closes #(issue)
- Fixes #(issue)

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [ ] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots

(optional) Please post any relevant screenshots that might help understanding the scope of this functionality.

## 🔗 Relevant URLs

(optional)

* https://example.com/feature/1
* https://example.com/feature/2

## 📕Extra Documentation

(optional)

Please include links to any external documentation such as requirements, manuals, etc.
